### PR TITLE
chore: Create minutes 2025-06-16.md

### DIFF
--- a/meetings/2025-06-16.md
+++ b/meetings/2025-06-16.md
@@ -1,0 +1,40 @@
+## Attendees
+
+- Ivan Asenov
+- Robert Walworth
+- Roger Barker
+- Sophie Bulloch
+- Pavel Borisov
+- Andrew Brandt
+- Georgi Stoykov
+- Anuj Saxena
+- Venilin Vasilev
+- Angelina Ceppaluni
+- Keith Kowal
+
+## Agenda
+
+- Recap from last SDK meeting
+  - Review HIP-1046
+
+## Additional Topics
+
+- Python SDK [pull 127](https://github.com/hiero-ledger/hiero-sdk-python/pull/127/)
+- Hiero-Solo-Action
+
+## Minutes
+
+- Ivan commented on HIP-1046 -> Meeting with Mirror Node team to be held 2025-06-16
+  - Interractions with transaction tool to be discussed
+- Shards & Realms: Discussion on how to handle persistent shard and realm support in Client.
+  - [Document](https://github.com/hiero-ledger/sdk-collaboration-hub/pull/28/files) updated 2025-06-16
+- TCK Regression Tests
+  - Discussed latest state of the TCK regression panel
+  - Robert & Ivaylo to discuss next steps with consensus team
+- Office Hours
+  - Trial office hours later in June
+- Python SDK [pull 127](https://github.com/hiero-ledger/hiero-sdk-python/pull/127/)
+  - Roger to add a new issue to capture type-hinting best practices w/ examples
+- Hiero-Solo-Action
+  - Solo-Action being used for testing in CPP SDK
+  - Recommend adding a flag for account creation with a number of accoutns to create


### PR DESCRIPTION
This pull request adds meeting notes for the SDK meeting held on 2025-06-16. The notes include details about attendees, agenda items, additional topics discussed, and meeting minutes.

### Meeting Notes:

* **Attendees**: A list of participants, including Ivan Asenov, Robert Walworth, and others.
* **Agenda**: Covered a recap of the previous SDK meeting and a review of HIP-1046.
* **Additional Topics**:
  - Discussion on the Python SDK pull request 127 and Hiero-Solo-Action.
* **Minutes**:
  - Updates on HIP-1046, including a planned meeting with the Mirror Node team.
  - Discussion on persistent shard and realm support in the Client, with a document update linked.
  - TCK regression tests and next steps with the consensus team.
  - Plans for trial office hours later in June.
  - Action items for Python SDK type-hinting best practices and Hiero-Solo-Action testing improvements.
