### PR TITLE
Java best practices continued

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -27,7 +27,7 @@ Use the following canonical mappings when turning meta types into Java:
 
 ## Immutable Objects
 
-If a non-abstract type and all the types its extends are only contain fields annotated with `@@immutable`, the type should be declared as a Java `record`.
+If a non-abstract type and all the types it extends only contain fields annotated with `@@immutable`, the type should be declared as a Java `record`.
 The following example gives an example of such a type:
 
 ```


### PR DESCRIPTION
This pull request updates the Java API best practices documentation to clarify and expand the handling of immutability and nullability in generated Java types. The changes introduce guidelines for when to use Java records versus classes based on field annotations, clarify the use of `@@nullable` instead of `@@optional`, and refine the recommended null handling for both immutable and mutable fields.