### PR TITLE
BigInteger added for Java

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -8,22 +8,41 @@ It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
 
 Use the following canonical mappings when turning meta types into Java:
 
-| Generic Type      | Java Type                                                                                          | Notes                                                                            |
-|-------------------|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `string`          | `java.lang.String`                                                                                 | -                                                                                |
-| `intX`            | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long` | For all definitions that are not `@@nullable` the primitive types should be used |
-| `uintX`           | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long` | For all definitions that are not `@@nullable` the primitive types should be used |
-| `double`          | `double`/`java.lang.Double`                                                                        | For all definitions that are not `@@nullable` the primitive types should be used |
-| `decimal`         | `java.math.BigDecimal`                                                                             | -                                                                                |
-| `bool`            | `boolean`/`java.lang.Boolean`                                                                      | For all definitions that are not `@@nullable` the primitive types should be used |
-| `bytes`           | `byte[]`/`java.lang.Byte[]`                                                                        | For all definitions that are not `@@nullable` the primitive types should be used |
-| `list<TYPE>`      | `java.util.List<TYPE>`                                                                             | lists in the public API should always be immutable                               |
-| `set<TYPE>`       | `java.util.Set<TYPE>`                                                                              | sets in the public API should always be immutable                                |
-| `map<KEY, VALUE>` | `java.util.Map<KEY, VALUE>`                                                                        | maps in the public API should always be immutable                                |
-| `date`            | `java.time.LocalDate`                                                                              | -                                                                                |
-| `time`            | `java.time.LocalTime`                                                                              | -                                                                                |
-| `dateTime`        | `java.time.LocalDateTime`                                                                          | -                                                                                |
-| `zonedDateTime`   | `java.time.ZonedDateTime`                                                                          | -                                                                                |
+| Generic Type      | Java Type                                                                                                                          | Notes                                                                            |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `string`          | `java.lang.String`                                                                                                                 | -                                                                                |
+| `intX`            | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long`, `java.math.BigInteger` | For all definitions that are not `@@nullable` the primitive types should be used |
+| `uintX`           | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long`, `java.math.BigInteger` | For all definitions that are not `@@nullable` the primitive types should be used |
+| `double`          | `double`/`java.lang.Double`                                                                                                        | For all definitions that are not `@@nullable` the primitive types should be used |
+| `decimal`         | `java.math.BigDecimal`                                                                                                             | -                                                                                |
+| `bool`            | `boolean`/`java.lang.Boolean`                                                                                                      | For all definitions that are not `@@nullable` the primitive types should be used |
+| `bytes`           | `byte[]`/`java.lang.Byte[]`                                                                                                        | For all definitions that are not `@@nullable` the primitive types should be used |
+| `list<TYPE>`      | `java.util.List<TYPE>`                                                                                                             | lists in the public API should always be immutable                               |
+| `set<TYPE>`       | `java.util.Set<TYPE>`                                                                                                              | sets in the public API should always be immutable                                |
+| `map<KEY, VALUE>` | `java.util.Map<KEY, VALUE>`                                                                                                        | maps in the public API should always be immutable                                |
+| `date`            | `java.time.LocalDate`                                                                                                              | -                                                                                |
+| `time`            | `java.time.LocalTime`                                                                                                              | -                                                                                |
+| `dateTime`        | `java.time.LocalDateTime`                                                                                                          | -                                                                                |
+| `zonedDateTime`   | `java.time.ZonedDateTime`                                                                                                          | -                                                                                |
+
+### Numeric Types
+
+The following table shows the mapping of numeric types between the meta-language and Java.
+For each numeric Java type a maximum numeric type is defined.
+
+| Max Numeric Type | Java Type                  |
+|------------------|----------------------------|
+| `int8`           | `byte`, `java.lang.Byte`   |
+| `int16`          | `short`, `java.lang.Short` |
+| `int32`          | `int`, `java.lang.Integer` |
+| `int64`          | `long`, `java.lang.Long`   |
+| `int256`         | `java.math.BigInteger`     |
+| `uint8`          | `byte`, `java.lang.Byte`   |
+| `uint16`         | `short`, `java.lang.Short` |
+| `uint32`         | `int`, `java.lang.Integer` |
+| `uint64`         | `long`, `java.lang.Long`   |
+| `uint256`        | `java.math.BigInteger`     |
+
 
 ## Immutable Objects
 

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -18,8 +18,8 @@ The following basic data types should be used in the API documentation.
 | Data Type         | Description                                                   |
 |-------------------|---------------------------------------------------------------|
 | `string`          | A sequence of characters                                      |
-| `intX`            | A signed integer of X bits                                    |
-| `uintX`           | An unsigned integer of X bits                                 |
+| `intX`            | A signed integer of X bits (0 < X <= 256)                     |
+| `uintX`           | An unsigned integer of X bits (0 < X <= 256)                  |
 | `double`          | A native floating-point number in 64-bit base-2 format        |
 | `decimal`         | A decimal number with arbitrary precision                     |
 | `bool`            | A boolean value                                               |


### PR DESCRIPTION
This pull request updates the API documentation and Java best practices guide to clarify and expand the handling of numeric types. The main improvements include specifying the valid range for `intX` and `uintX` types, adding support for larger numeric types in Java mappings, and introducing a new table that details the correspondence between meta-language numeric types and Java types.

**API Documentation Updates:**

* Clarified that `intX` and `uintX` types represent signed and unsigned integers where X can range from 1 to 256 bits.

**Java Best Practices Guide Updates:**

* Expanded the Java type mappings for `intX` and `uintX` to include `java.math.BigInteger`, supporting up to 256-bit integers.
* Added a new "Numeric Types" section with a table mapping each maximum numeric type (`int8`, `int16`, `int32`, `int64`, `int256`, `uint8`, `uint16`, `uint32`, `uint64`, `uint256`) to its corresponding Java type, improving clarity for SDK authors.