### PR TITLE
async handling in Java & some todos

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -522,6 +522,43 @@ public class Example {
 }
 ```
 
+## Asynchronous methods
+
+Methods that are annotated with `@@async` in the meta-language must return a `java.util.concurrent.CompletionStage<T>` instead of a concrete type.
+The benefit of `java.util.concurrent.CompletionStage<T>` against `java.util.concurrent.CompletableFuture<T>` is, that it is an interface.
+Implementations can use `java.util.concurrent.CompletableFuture<T>` since it implements the `java.util.concurrent.CompletionStage<T>` interface.
+Against `java.util.concurrent.Future<T>` the `java.util.concurrent.CompletionStage<T>` interface is more flexible and provides more functionality.
+`java.util.concurrent.CompletionStage<T>` contains the `CompletableFuture<T> toCompletableFuture()` method that can be used to transform it to a `java.util.concurrent.CompletableFuture<T>` or `java.util.concurrent.Future<T>`.
+
+Example of an asynchronous method:
+
+```java
+public interface ExampleService {
+    
+    CompletionStage<Example> getExample(final String id);
+
+}
+```
+
+In general an API should provide a synchronous method as alternative to the asynchronous method.
+The synchronous method can be defined and implemented as follows:
+
+```java
+public interface ExampleService {
+    
+    CompletionStage<Example> getExample();
+    
+    default Example getExampleSync(final long timeout, final TimeUnit unit) {
+        return getExample(id).toCompletableFuture().get(timeout, unit);
+    }
+
+}
+```
+
+The sample uses `long timeout, TimeUnit unit` as parameters for the synchronous method.
+That is the best practice in Java to ensure that the synchronous method can be called from multiple threads.
+Instead of just defining a `long timeoutInMs` the usage of `TimeUnit` is recommended.
+
 ## Questions & Comments
 
 We need to define a naming pattern for the usage of `Optional` in a `record`.
@@ -530,11 +567,9 @@ We need to define a naming pattern for the usage of `Optional` in a `record`.
 
 The following list contains some descriptions of problems and missing features based on using an AI to create code based on the documentation.
 
-- `java.util.concurrent.CompletionStage` should be used instead of `java.util.concurrent.CompletableFuture` or `java.util.concurrent.Future` in the public API for async methods.
 - Factory methods should be implemented as static methods in the type that is created by the factory method instead of creating a factory class per namespace.
 - `Objects.requireNonNull(obj, message)` contains as message only the obj name instead of the message "NAME must not be null" (NAME is a placeholder for the actual name of the parameter).
 - Even types that have only immutable fields/attributes are implemented as classes instead of records.
 - `@org.jspecify.annotations.NonNull` and `@org.jspecify.annotations.Nullable` annotations are not used in the public API. They should be added wherever possible.
 - Parameters of methods and constructors should always be defined as `final`.
-- 
 

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -178,6 +178,8 @@ void resetCache()
 Method annotations can be used to provide additional information about methods.
 The following annotations should be used:
 - `@@async`: Indicates that the method is asynchronous and returns a promise or future.
+  To make APIs easily useable by experts and newcomers, it makes sense to always provide a synchronous version of the method.
+  An API definition in the meta-language does not need to add the synchronous version explicitly.
 - `@@throws(error-type-a[, ...])`: Indicates that the method can throw an exception/error.
   The error-types should be stable identifiers, not transport-specific.
   Use lowercase-kebab for error identifiers (e.g., `not-found-error`, `parse-error`).

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -60,7 +60,6 @@ abstraction PackedTransaction {
   void sign(publicKey:PublicKey, transactionSigner:TransactionSigner) // sign the transaction, if the lang supports it, we should provide a fluent API (return this)
 
   @@async Response send() // send the transaction, we should provide async and sync versions in best case
-  Response sendAndWait(long timeout) // send the transaction, in milliseconds, a better lang specific type can be used
 }
 
 // The response of a transaction send request
@@ -68,10 +67,8 @@ Response {
   @immutable transactionId:TransactionId // the id of the transaction
 
   @@async Receipt queryReceipt() // query for the receipt of the transaction, we should provide async and sync versions in best case
-  Receipt queryReceiptAndWait(long timeout) // query for the receipt of the transaction, in milliseconds, a better lang specific type can be used
   
   @async Record queryRecord() // query for the record of the transaction, we should provide async and sync versions in best case
-  Record queryRecordAndWait(long timeout) // query for the record of the transaction, in milliseconds, a better lang specific type can be used
 }
 
 // The receipt of a transaction


### PR DESCRIPTION
This pull request enhances the documentation and API guidelines for asynchronous methods in Java, clarifying best practices for providing both asynchronous and synchronous API variants. It also updates the prototype API definitions to align with these recommendations and adds a checklist of improvements based on AI-generated code reviews.

**Java API Best Practices**

* Added a new section on asynchronous methods in `guides/api-best-practices-java.md`, explaining the use of `CompletionStage<T>` for async APIs, the rationale for preferring it over `CompletableFuture<T>` and `Future<T>`, and providing code examples for both async and sync method variants.
* Included a checklist of recommended improvements based on AI-generated code, such as using static factory methods, proper null checks, preferring records for immutable types, adding nullability annotations, and marking parameters as `final`.

**API Guidelines**

* Updated the annotation documentation in `guides/api-guideline.md` to recommend always providing a synchronous version of any method marked with `@@async` for better usability, and clarified that the meta-language does not require explicit definition of the sync version.

**Prototype API Updates**

* Removed explicit synchronous variants (`sendAndWait`, `queryReceiptAndWait`, `queryRecordAndWait`) from the transaction API in `v3-sandbox/prototype-api/transactions.md`, reflecting the guideline that synchronous methods do not need to be defined in the meta-language but should be provided in the actual API implementation.