### PR TITLE
Some more best pratices for Java

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -245,7 +245,7 @@ public class Team {
 
 In Java we use the `org.jspecify:jspecify` library to annotate nullability of types.
 The 2 annotations `org.jspecify.annotations.NonNull` and `org.jspecify.annotations.Nullable` are used to annotate nullability of types.
-All non-primitive constructor parameters, method parameters and method return values must be annotated with one of these annotations.
+All non-primitive constructor parameters, method parameters and method return values of the public API must be annotated with one of these annotations.
 The annotations must be used consistently throughout the full implementation.
 
 For the generic types `intX`, `uintX`, `double`, and `bool` wrapper classes


### PR DESCRIPTION
This pull request updates the Java API best practices guide to clarify and strengthen recommendations around nullability checks, annotation usage, and the use of the `final` keyword. The changes provide more explicit instructions and examples for enforcing null safety, consistent annotation, and immutability in Java code.

**Nullability and annotation enforcement:**

* Expanded the section on nullability to require consistent use of `@NonNull` and `@Nullable` annotations throughout the implementation, and clarified the requirements for null checks in Java using `Objects.requireNonNull(param, msg)` with a standardized message format. An example was added to illustrate early null checks in setters to prevent late exceptions.
* Updated the list of problems to note the importance of using the correct message format ("NAME must not be null") for null checks, and emphasized the need to use `@NonNull` and `@Nullable` annotations in public APIs.

**Immutability and record usage:**

* Removed the redundant section on declaring types as Java records when all fields are annotated as immutable, streamlining the guidance.

**Immutability and code style:**

* Added a new section recommending consistent use of the `final` keyword for fields, parameters, local variables, classes, and records to promote immutability and clarity in code.
* Highlighted the importance of defining method and constructor parameters as `final` in the list of best practices.