### PR TITLE
New key import/export API based on several discussions in the community

### DIFF
--- a/v3-sandbox/prototype-api/keys.md
+++ b/v3-sandbox/prototype-api/keys.md
@@ -51,7 +51,7 @@ abstraction Key {
     @@immutable type: KeyType //the type of the key
     
     bytes toBytes() // returns the key in the RAW encoding
-    @@throws(not-supported-format) string toString(KeyContainer container, KeyEncoding encoding) // returns the key in the specified container format and encoding or throws an exception if the format is not supported
+    @@throws(illegal-format) string toString(KeyContainer container, KeyEncoding encoding) // returns the key in the specified container format and encoding or throws an exception if the format is not supported
 }
 
 // a key pair
@@ -165,7 +165,7 @@ JWK;
 
 The following examples show the different key formats as String representations.
 
-#### PKSC8 + DER (Private Key)
+#### PKCS#8 + DER (Private Key)
 
 The string is a hex dump of the DER bytes.
 ```
@@ -173,7 +173,7 @@ The string is a hex dump of the DER bytes.
 E1 5D 8F 21 A7 01 73 09 BB 55 88 52 03 9B C7 5C
 ```
 
-#### PKSC8 + PEM (Private Key)
+#### PKCS#8 + PEM (Private Key)
 
 ```
 -----BEGIN PRIVATE KEY-----


### PR DESCRIPTION
This pull request introduces significant enhancements and clarifications to the cryptographic key management API documentation. The changes focus on expanding support for key formats and encodings, improving type safety, and providing clear rules and examples for key import/export operations.

### API Model Extensions

* Added new enums: `KeyType` (distinguishing public and private keys), expanded `KeyEncoding` (DER, PEM, MULTIBASE, JSON, BASE64), and introduced `KeyContainer` (PKCS8, SPKI, MULTICODEC, JWK) to more accurately model supported key types, encodings, and container formats.
* Updated the `Key` abstraction to include the key type and new methods for exporting keys in various formats and encodings, with error handling for unsupported combinations.

### Import/Export API Improvements

* Refactored key creation methods to require explicit specification of container and encoding, improving clarity and preventing illegal format errors. Added convenience methods for common PEM formats.
* Provided detailed rules for which container formats support which key types and encodings, including a basic implementation of the logic for validation.

### Documentation and Examples

* Added comprehensive examples for key representations in all supported formats and encodings (PKCS8/DER, PKCS8/PEM, SPKI/DER, SPKI/PEM, MULTICODEC/MULTIBASE, MULTICODEC/BASE64, JWK/JSON) for both public and private keys.
* Clarified behavior for JWK private keys regarding the inclusion of the public key property ("x") during import/export.

These changes lay a foundation for robust key management, ensuring developers have clear guidance and flexibility when working with various cryptographic key formats.