### PR TITLE
best practices for other languages started

### DIFF
--- a/guides/api-best-practices-cpp.md
+++ b/guides/api-best-practices-cpp.md
@@ -1,0 +1,24 @@
+# C++ API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete C++ patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | C++ Type                                      | Notes                                   |
+|-------------------|-----------------------------------------------|-----------------------------------------|
+| `string`          | `std::string`                                 | -                                       |
+| `intX`            | `int8_t`, `int16_t`, `int32_t`, `int64_t`     | From `<cstdint>`                        |
+| `uintX`           | `uint8_t`, `uint16_t`, `uint32_t`, `uint64_t` | From `<cstdint>`                        |
+| `double`          | `double`                                      | -                                       |
+| `decimal`         | Custom or third-party library                 | No standard decimal type                |
+| `bool`            | `bool`                                        | -                                       |
+| `bytes`           | `std::vector<std::byte>`                      | C++17+                                  |
+| `list<TYPE>`      | `std::vector<TYPE>`                           | -                                       |
+| `set<TYPE>`       | `std::set<TYPE>`                              | -                                       |
+| `map<KEY, VALUE>` | `std::map<KEY, VALUE>`                        | Or `std::unordered_map` for performance |
+| `date`            | `std::chrono::year_month_day`                 | C++20                                   |
+| `time`            | `std::chrono::time_of_day`                    | C++20                                   |
+| `dateTime`        | `std::chrono::system_clock::time_point`       | -                                       |
+| `zonedDateTime`   | `std::chrono::zoned_time`                     | C++20                                   |

--- a/guides/api-best-practices-go.md
+++ b/guides/api-best-practices-go.md
@@ -1,0 +1,50 @@
+# Go API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete Go patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | Go Type                                          | Notes                  |
+|-------------------|--------------------------------------------------|------------------------|
+| `string`          | `string`                                         | -                      |
+| `intX`            | `int8`, `int16`, `int32`, `int64`                | -                      |
+| `uintX`           | `uint8`, `uint16`, `uint32`, `uint64`            | -                      |
+| `double`          | `float64`                                        | -                      |
+| `decimal`         | Third-party package (e.g., `shopspring/decimal`) | -                      |
+| `bool`            | `bool`                                           | -                      |
+| `bytes`           | `[]byte`                                         | -                      |
+| `list<TYPE>`      | `[]TYPE`                                         | -                      |
+| `set<TYPE>`       | `map[TYPE]struct{}`                              | No native set type     |
+| `map<KEY, VALUE>` | `map[KEY]VALUE`                                  | -                      |
+| `date`            | `time.Time`                                      | Store only date part   |
+| `time`            | Custom or `time.Time`                            | -                      |
+| `dateTime`        | `time.Time`                                      | -                      |
+| `zonedDateTime`   | `time.Time`                                      | Includes location info |
+
+## Immutable Objects
+
+Go doesn't enforce immutability; use conventions:
+
+```go
+type Person struct {
+    name string  // Unexported = "private"
+    age  int32
+}
+
+func NewPerson(name string, age int32) (*Person, error) {
+    if name == "" {
+        return nil, errors.New("name must not be empty")
+    }
+    return &Person{name: name, age: age}, nil
+}
+
+func (p *Person) Name() string {
+    return p.name
+}
+
+func (p *Person) Age() int32 {
+    return p.age
+}
+```

--- a/guides/api-best-practices-js.md
+++ b/guides/api-best-practices-js.md
@@ -1,0 +1,40 @@
+# JavaScript API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete JavaScript
+patterns, conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | JavaScript Type                          | Notes                          |
+|-------------------|------------------------------------------|--------------------------------|
+| `string`          | `string`                                 | -                              |
+| `intX`/`uintX`    | `number` or `BigInt`                     | Use `BigInt` for values > 2^53 |
+| `double`          | `number`                                 | -                              |
+| `decimal`         | Third-party library (e.g., `decimal.js`) | -                              |
+| `bool`            | `boolean`                                | -                              |
+| `bytes`           | `Uint8Array` or `ArrayBuffer`            | -                              |
+| `list<TYPE>`      | `Array<TYPE>` or `TYPE[]`                | -                              |
+| `set<TYPE>`       | `Set<TYPE>`                              | -                              |
+| `map<KEY, VALUE>` | `Map<KEY, VALUE>`                        | -                              |
+| `date`            | `Date` or custom                         | JS `Date` includes time        |
+| `time`            | Custom                                   | No native time-only type       |
+| `dateTime`        | `Date`                                   | -                              |
+| `zonedDateTime`   | `Date` or `Temporal` (future)            | -                              |
+
+## Immutable Objects
+
+Use `Object.freeze()`:
+
+```javascript
+class Person {
+    constructor(name, age) {
+        if (!name) {
+            throw new Error('name must not be empty');
+        }
+        this.name = name;
+        this.age = age;
+        Object.freeze(this);
+    }
+}
+```

--- a/guides/api-best-practices-python.md
+++ b/guides/api-best-practices-python.md
@@ -1,0 +1,24 @@
+# Python API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete Python patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | Python Type                       | Notes                                              |
+|-------------------|-----------------------------------|----------------------------------------------------|
+| `string`          | `str`                             | -                                                  |
+| `intX`            | `int`                             | Python `int` is arbitrary precision                |
+| `uintX`           | `int`                             | Use validation for non-negative values             |
+| `double`          | `float`                           | -                                                  |
+| `decimal`         | `decimal.Decimal`                 | -                                                  |
+| `bool`            | `bool`                            | -                                                  |
+| `bytes`           | `bytes` or `bytearray`            | Use `bytes` for immutable, `bytearray` for mutable |
+| `list<TYPE>`      | `list[TYPE]`                      | Use `typing.List` for older Python versions        |
+| `set<TYPE>`       | `set[TYPE]`                       | -                                                  |
+| `map<KEY, VALUE>` | `dict[KEY, VALUE]`                | -                                                  |
+| `date`            | `datetime.date`                   | -                                                  |
+| `time`            | `datetime.time`                   | -                                                  |
+| `dateTime`        | `datetime.datetime`               | -                                                  |
+| `zonedDateTime`   | `datetime.datetime` with `tzinfo` | Use `zoneinfo.ZoneInfo` (Python 3.9+)              |

--- a/guides/api-best-practices-rust.md
+++ b/guides/api-best-practices-rust.md
@@ -1,0 +1,24 @@
+# Rust API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete Rust patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | Rust Type                                       | Notes                                       |
+|-------------------|-------------------------------------------------|---------------------------------------------|
+| `string`          | `String` or `&str`                              | Use `String` for owned, `&str` for borrowed |
+| `intX`            | `i8`, `i16`, `i32`, `i64`, `i128`               | -                                           |
+| `uintX`           | `u8`, `u16`, `u32`, `u64`, `u128`               | -                                           |
+| `double`          | `f64`                                           | -                                           |
+| `decimal`         | Third-party crate (e.g., `rust_decimal`)        | -                                           |
+| `bool`            | `bool`                                          | -                                           |
+| `bytes`           | `Vec<u8>` or `&[u8]`                            | -                                           |
+| `list<TYPE>`      | `Vec<TYPE>`                                     | -                                           |
+| `set<TYPE>`       | `HashSet<TYPE>` or `BTreeSet<TYPE>`             | -                                           |
+| `map<KEY, VALUE>` | `HashMap<KEY, VALUE>` or `BTreeMap<KEY, VALUE>` | -                                           |
+| `date`            | `chrono::NaiveDate`                             | Using `chrono` crate                        |
+| `time`            | `chrono::NaiveTime`                             | Using `chrono` crate                        |
+| `dateTime`        | `chrono::NaiveDateTime`                         | Using `chrono` crate                        |
+| `zonedDateTime`   | `chrono::DateTime<Tz>`                          

--- a/guides/api-best-practices-swift.md
+++ b/guides/api-best-practices-swift.md
@@ -1,0 +1,36 @@
+# Swift API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete Swift patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | Swift Type                                    | Notes                                           |
+|-------------------|-----------------------------------------------|-------------------------------------------------|
+| `string`          | `String`                                      | -                                               |
+| `intX`            | `Int8`, `Int16`, `Int32`, `Int64`, `Int`      | Use appropriate size; `Int` for general cases   |
+| `uintX`           | `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UInt` | Use appropriate size; `UInt` for general cases  |
+| `double`          | `Double`                                      | -                                               |
+| `decimal`         | `Decimal`                                     | -                                               |
+| `bool`            | `Bool`                                        | -                                               |
+| `bytes`           | `Data`                                        | Foundation type for byte arrays                 |
+| `list<TYPE>`      | `[TYPE]`                                      | Arrays should be immutable where possible       |
+| `set<TYPE>`       | `Set<TYPE>`                                   | Sets should be immutable where possible         |
+| `map<KEY, VALUE>` | `[KEY: VALUE]`                                | Dictionaries should be immutable where possible |
+| `date`            | `Date` or custom `DateOnly`                   | Consider custom wrapper for date-only values    |
+| `time`            | Custom `TimeOnly`                             | Foundation lacks time-only type                 |
+| `dateTime`        | `Date`                                        | -                                               |
+| `zonedDateTime`   | `Date` with `TimeZone`                        | Store timezone separately if needed             |
+
+## Immutable Objects
+
+For types with only `@@immutable` fields, use `struct` with `let` properties:
+
+```swift
+// @@immutable name:string
+// @@immutable age:int32
+struct Person {
+    let name: String
+    let age: Int32
+}

--- a/guides/api-best-practices-ts.md
+++ b/guides/api-best-practices-ts.md
@@ -1,0 +1,24 @@
+# TypeScript API Implementation Guideline
+
+This document translates the [language-agnostic API meta-definition](api-guideline.md) into concrete TypeScript
+patterns,
+conventions, and ready‑to‑copy code templates.
+It aims to keep SDK APIs consistent, ergonomic, and maintainable across modules.
+
+## Type Mapping
+
+| Generic Type      | TypeScript Type                                | Notes                                      |
+|-------------------|------------------------------------------------|--------------------------------------------|
+| `string`          | `string`                                       | -                                          |
+| `intX`/`uintX`    | `number` or `bigint`                           | Use `bigint` for values > 2^53             |
+| `double`          | `number`                                       | -                                          |
+| `decimal`         | Third-party library or custom                  | -                                          |
+| `bool`            | `boolean`                                      | -                                          |
+| `bytes`           | `Uint8Array` or `ArrayBuffer`                  | -                                          |
+| `list<TYPE>`      | `Array<TYPE>` or `TYPE[]`                      | Prefer `ReadonlyArray<TYPE>` for immutable |
+| `set<TYPE>`       | `Set<TYPE>` or `ReadonlySet<TYPE>`             | -                                          |
+| `map<KEY, VALUE>` | `Map<KEY, VALUE>` or `ReadonlyMap<KEY, VALUE>` | -                                          |
+| `date`            | `Date` or custom type                          | -                                          |
+| `time`            | Custom type                                    | No native time-only type                   |
+| `dateTime`        | `Date`                                         | -                                          |
+| `zonedDateTime`   | `Date` or `Temporal` (future)                  | -                                          |

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -5,7 +5,21 @@ Following these guidelines will help ensure that APIs are consistent, easy to us
 Next to that the guidelines define a syntax for documenting the APIs in a language-agnostic way for proposals.
 
 The [proposals](../proposals) folder contains design documents of new features or changes for our SDKs.
-Each proposal should include a section that documents the API in a language-agnostic way by using the guidelines defined in this document.
+Each proposal should include a section that documents the API in a language-agnostic way by using the guidelines defined
+in this document.
+
+## Concrete implementations
+
+We provide concrete implementation guidelines for the following programming languages:
+
+- [Rust API Implementation Guideline](api-best-practices-rust.md)
+- [C++ API Implementation Guideline](api-best-practices-cpp.md)
+- [TypeScript API Implementation Guideline](api-best-practices-ts.md)
+- [Python API Implementation Guideline](api-best-practices-python.md)
+- [Java API Implementation Guideline](api-best-practices-java.md)
+- [Go API Implementation Guideline](api-best-practices-go.md)
+- [JavaScript API Implementation Guideline](api-best-practices-js.md)
+- [Swift API Implementation Guideline](api-best-practices-swift.md)
 
 ## Syntax
 
@@ -18,7 +32,7 @@ The following basic data types should be used in the API documentation.
 | Data Type         | Description                                                           |
 |-------------------|-----------------------------------------------------------------------|
 | `string`          | A sequence of characters                                              |
-| `intX`            | A signed integer of X bits (8 <= X <= 256)                             |
+| `intX`            | A signed integer of X bits (8 <= X <= 256)                            |
 | `uintX`           | An unsigned integer of X bits (8 <= X <= 256)                         |
 | `double`          | A native floating-point number in 64-bit base-2 format                |
 | `decimal`         | A decimal number with arbitrary precision                             |
@@ -38,6 +52,7 @@ The following basic data types should be used in the API documentation.
 Complex data types can be defined using the basic data types and other complex data types.
 A complex data type definition can contain [attributes](#attributes) and [methods](#methods).
 The following syntax should be used to define complex data types:
+
 ```
 DataTypeName {
     fieldName1: DataType1
@@ -50,25 +65,32 @@ DataTypeName {
 
 Type annotations apply to a complex data type as a whole (as opposed to a single attribute or a method).
 The following annotations should be used:
-- `@@oneOf(field1, field2[, ...])`: Exactly one of the referenced fields can be non-null/non-undefined at any given time.
-- `@@oneOrNoneOf(field1, field2[, ...])`: Exactly one of the referenced fields can be non-null/non-undefined at any given time or all fields are null/undefined.
+
+- `@@oneOf(field1, field2[, ...])`: Exactly one of the referenced fields can be non-null/non-undefined at any given
+  time.
+- `@@oneOrNoneOf(field1, field2[, ...])`: Exactly one of the referenced fields can be non-null/non-undefined at any
+  given time or all fields are null/undefined.
 - `@@finalType`: Indicates that the type is final and cannot be extended.
 
 Rules and recommendations for `@@oneOf`:
+
 - All listed fields must be declared with `@@nullable`
 - None or all listed fields must be declared with `@@immutable`.
 - If the fields are not `@@immutable` and a field is set, an SDK must unset all other fields
 - If the fields are not `@@immutable` and the currently set field is unset, an SDK must throw an error.
 - None or exactly one of the listed fields must be annotated by `@@default(value)`
-- If the fields are not `@@immutable` and none is annotated by `@@default(value)` at least one must be set by the constructor to not end in an invalid state. 
+- If the fields are not `@@immutable` and none is annotated by `@@default(value)` at least one must be set by the
+  constructor to not end in an invalid state.
 
 Rules and recommendations for `@@oneOrNoneOf`:
+
 - All listed fields must be declared with `@@nullable`
 - None or all listed fields must be declared with `@@immutable`.
 - If the fields are not `@@immutable` and a field is set, an SDK must unset all other fields
 - None or exactly one of the listed fields must be annotated by `@@default(value)`
 
 Examples:
+
 ```
 @@oneOf(email, phone)
 ContactInfo {    
@@ -83,10 +105,12 @@ ContactInfo {
 Complex data types can inherit from other complex data types to reuse fields and methods.
 
 Definition of an abstract type:
+
 - Use `abstraction` to declare an abstract type.
 - We do not define if it should be a class or an interface (that is language specific).
 
 Syntax example:
+
 ```
 abstraction Copyable {
     copy(): Copyable
@@ -94,11 +118,13 @@ abstraction Copyable {
 ```
 
 Definition of a child type:
+
 - Use `extends` to declare a child type.
 - Multiple inheritance is supported but should be avoided in general.
 - Inherited members: All fields and methods from the parent are inherited by the child (since we only define public API)
 
 Syntax examples:
+
 ```
 Person {
     name: string
@@ -130,6 +156,7 @@ abstraction Factory<$$Product> {
 The `$$Product` type parameter is used in the `create` method to define the return type of the method.
 A complexe type that extends a generic type can use the type parameter in its own definition.
 A concrete example of the syntax looks like this:
+
 ```
 CarFactory extends Factory<Car> {
 }
@@ -154,6 +181,7 @@ In the given example, the `FruitFactory` provides a `create` method that returns
 ### Enumerations
 
 Enumerations can be defined using the following syntax:
+
 ```
 enum EnumName {
     VALUE1
@@ -161,7 +189,8 @@ enum EnumName {
 }
 ```
 
-[Attributes](#attributes) can be added to enumerations. Attributes added to enumerations must be immutable (annotated with `@@immutable`).
+[Attributes](#attributes) can be added to enumerations. Attributes added to enumerations must be immutable (annotated
+with `@@immutable`).
 
 ```
 enum EnumName {
@@ -186,6 +215,7 @@ enum EnumName {
 ### Attributes
 
 Attributes can be defined using the following syntax:
+
 ```
     fieldName: DataType
 ```
@@ -194,14 +224,20 @@ Attributes can be defined using the following syntax:
 
 Attribute annotations can be used to provide additional information about attributes in complex data types.
 The following annotations should be used:
+
 - `@@immutable`: Indicates that the field is immutable and cannot be changed after creation.
 - `@@nullable`: Indicates that the field can be null or undefined (language-specific).
 - `@@default(value)`: Indicates that the field has a default value.
-- `@@min(value)`: Indicates the minimum value for numeric fields. Should be included if the value must be enforced at the SDK level.
-- `@@max(value)`: Indicates the maximum value for numeric fields. Should be included if the value must be enforced at the SDK level.
-- `@@minLength(value)`: Indicates the minimum length for string fields. Should be included if the value must be enforced at the SDK level.
-- `@@maxLength(value)`: Indicates the maximum length for string fields. Should be included if the value must be enforced at the SDK level.
-- `@@pattern(regex)`: Indicates a regex pattern that the string field must match. Should be included if the value must be enforced at the SDK level.
+- `@@min(value)`: Indicates the minimum value for numeric fields. Should be included if the value must be enforced at
+  the SDK level.
+- `@@max(value)`: Indicates the maximum value for numeric fields. Should be included if the value must be enforced at
+  the SDK level.
+- `@@minLength(value)`: Indicates the minimum length for string fields. Should be included if the value must be enforced
+  at the SDK level.
+- `@@maxLength(value)`: Indicates the maximum length for string fields. Should be included if the value must be enforced
+  at the SDK level.
+- `@@pattern(regex)`: Indicates a regex pattern that the string field must match. Should be included if the value must
+  be enforced at the SDK level.
 
 ### Methods
 
@@ -213,6 +249,7 @@ ReturnType methodName(param1: DataType1, param2: DataType2)
 
 If a method has no return type, the return type should be `void`.
 An example of a method with no return type:
+
 ```
 void resetCache()
 ```
@@ -221,8 +258,10 @@ void resetCache()
 
 Method annotations can be used to provide additional information about methods.
 The following annotations should be used:
+
 - `@@async`: Indicates that the method is asynchronous and returns a promise or future.
-  To make APIs easily useable by experts and newcomers, it makes sense to always provide a synchronous version of the method.
+  To make APIs easily useable by experts and newcomers, it makes sense to always provide a synchronous version of the
+  method.
   An API definition in the meta-language does not need to add the synchronous version explicitly.
 - `@@throws(error-type-a[, ...])`: Indicates that the method can throw an exception/error.
   The error-types should be stable identifiers, not transport-specific.
@@ -230,7 +269,8 @@ The following annotations should be used:
 
 #### Method Parameter annotations
 
-The following attribute annotations can be used on method parameters: `@@nullable`, `@@min(value)`, `@@max(value)`, `@@minLength(value)`, `@@maxLength(value)`, `@@pattern(regex)`
+The following attribute annotations can be used on method parameters: `@@nullable`, `@@min(value)`, `@@max(value)`,
+`@@minLength(value)`, `@@maxLength(value)`, `@@pattern(regex)`
 
 #### Method Return Types annotations
 
@@ -240,6 +280,7 @@ The following attribute annotations can be used on method return types: `@@nulla
 
 Namespaces can be used to group related data types and methods.
 The following syntax should be used to define namespaces:
+
 ```
 namespace transactions
 
@@ -262,6 +303,7 @@ namespace transactions
 ```
 
 If a namespace depends on other namespaces, use the `requires` keyword to declare the dependencies:
+
 ```
 namespace transactions
 requires common, keys


### PR DESCRIPTION
Added new API best practices documents for the following languages, each providing type mapping tables and code conventions:
  - Rust (`api-best-practices-rust.md`)
  - C++ (`api-best-practices-cpp.md`)
  - TypeScript (`api-best-practices-ts.md`)
  - Python (`api-best-practices-python.md`)
  - Go (`api-best-practices-go.md`)
  - JavaScript (`api-best-practices-js.md`)
  - Swift (`api-best-practices-swift.md`)
