### PR TITLE
docs: typed receipts, universal records, and named response aliases for V3 transactions

### DIFF
--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -199,33 +199,6 @@ abstraction FruitFactory<$$Product extends Fruit> {
 In the given example, the `FruitFactory` provides a `create` method that returns a `Fruit`.
 `Fruit` must be a concrete complexe type (not a generic type parameter).
 
-#### Type Aliases
-
-A type alias gives a name to an existing type expression without creating a new, distinct type. Aliases
-are useful for naming specific instantiations of generic types so that the name appears in call sites,
-IDE completions, and documentation instead of the raw generic expression.
-
-Use the following syntax to declare a type alias:
-
-```
-@@alias AliasName = TargetType
-```
-
-A concrete example:
-
-```
-@@alias StringList = list<string>
-@@alias AccountCreateResponse = Response<AccountCreateReceipt>
-```
-
-Rules and guidelines for `@@alias`:
-
-- An alias declaration has no body — it cannot declare fields or methods.
-- An alias may refer to any type expression, including generic instantiations.
-- Aliases must not be used to introduce new behavior. If any field or method is needed, define a new
-  complex type using `extends` instead.
-- Language implementations translate `@@alias` according to their language-specific best practice guide.
-
 ### Enumerations
 
 Enumerations can be defined using the following syntax:
@@ -259,6 +232,33 @@ enum EnumName {
     int calcPrimitiveType()
 }
 ```
+
+### Type Aliases
+
+A type alias gives a name to an existing type expression without creating a new, distinct type. Aliases
+are useful for naming specific instantiations of generic types so that the name appears in call sites,
+IDE completions, and documentation instead of the raw generic expression.
+
+Use the following syntax to declare a type alias:
+
+```
+@@alias AliasName = TargetType
+```
+
+A concrete example:
+
+```
+@@alias StringList = list<string>
+@@alias AccountCreateResponse = Response<AccountCreateReceipt>
+```
+
+Rules and guidelines for `@@alias`:
+
+- An alias declaration has no body — it cannot declare fields or methods.
+- An alias may refer to any type expression, including generic instantiations.
+- Aliases must not be used to introduce new behavior. If any field or method is needed, define a new
+  complex type using `extends` instead.
+- Language implementations translate `@@alias` according to their language-specific best practice guide.
 
 ### Attributes
 

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -233,33 +233,6 @@ enum EnumName {
 }
 ```
 
-### Type Aliases
-
-A type alias gives a name to an existing type expression without creating a new, distinct type. Aliases
-are useful for naming specific instantiations of generic types so that the name appears in call sites,
-IDE completions, and documentation instead of the raw generic expression.
-
-Use the following syntax to declare a type alias:
-
-```
-@@alias AliasName = TargetType
-```
-
-A concrete example:
-
-```
-@@alias StringList = list<string>
-@@alias AccountCreateResponse = Response<AccountCreateReceipt>
-```
-
-Rules and guidelines for `@@alias`:
-
-- An alias declaration has no body — it cannot declare fields or methods.
-- An alias may refer to any type expression, including generic instantiations.
-- Aliases must not be used to introduce new behavior. If any field or method is needed, define a new
-  complex type using `extends` instead.
-- Language implementations translate `@@alias` according to their language-specific best practice guide.
-
 ### Attributes
 
 Attributes can be defined using the following syntax:

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -199,6 +199,36 @@ abstraction FruitFactory<$$Product extends Fruit> {
 In the given example, the `FruitFactory` provides a `create` method that returns a `Fruit`.
 `Fruit` must be a concrete complexe type (not a generic type parameter).
 
+#### Type Aliases
+
+A type alias gives a name to an existing type expression without creating a new, distinct type. Aliases
+are useful for naming specific instantiations of generic types so that the name appears in call sites,
+IDE completions, and documentation instead of the raw generic expression.
+
+Use the following syntax to declare a type alias:
+
+```
+@@alias AliasName = TargetType
+```
+
+A concrete example:
+
+```
+@@alias StringList = list<string>
+@@alias AccountCreateResponse = Response<AccountCreateReceipt>
+```
+
+Rules and guidelines for `@@alias`:
+
+- An alias declaration has no body — it cannot declare fields or methods.
+- An alias may refer to any type expression, including generic instantiations.
+- Aliases must not be used to introduce new behavior. If any field or method is needed, define a new
+  complex type using `extends` instead.
+- Language implementations translate `@@alias` to the most idiomatic alias mechanism available
+  (e.g. `type` in TypeScript/Rust/Go, `typealias` in Swift, `using` in C++). Languages without a
+  native alias mechanism (e.g. Java) must implement the alias as an empty `final` class or record
+  that extends the target type. The language-specific best practice guide specifies the exact pattern.
+
 ### Enumerations
 
 Enumerations can be defined using the following syntax:

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -224,10 +224,7 @@ Rules and guidelines for `@@alias`:
 - An alias may refer to any type expression, including generic instantiations.
 - Aliases must not be used to introduce new behavior. If any field or method is needed, define a new
   complex type using `extends` instead.
-- Language implementations translate `@@alias` to the most idiomatic alias mechanism available
-  (e.g. `type` in TypeScript/Rust/Go, `typealias` in Swift, `using` in C++). Languages without a
-  native alias mechanism (e.g. Java) must implement the alias as an empty `final` class or record
-  that extends the target type. The language-specific best practice guide specifies the exact pattern.
+- Language implementations translate `@@alias` according to their language-specific best practice guide.
 
 ### Enumerations
 

--- a/v3-sandbox/prototype-api/transactions-accounts.md
+++ b/v3-sandbox/prototype-api/transactions-accounts.md
@@ -14,24 +14,24 @@ namespace transactions-accounts
 requires common, transactions, keys
 
 @@finalType
-AccountCreateTransactionBuilder extends transactions.TransactionBuilder<AccountCreateTransactionBuilder> {
-    @@nullable accountMemo:string
-    @@default(0) initialBalance:common.Hbar
-    key:keys.PublicKey
+AccountCreateTransactionBuilder extends transactions.TransactionBuilder<AccountCreateTransactionBuilder, AccountCreateResponse> {
+    @@nullable accountMemo: string
+    @@default(0) initialBalance: common.Hbar
+    key: keys.PublicKey
 }
 
 @@finalType
-AccountCreateResponse extends transactions.Response<AccountCreateReceipt, AccountCreateRecord> {
+// Named response type for ergonomics — intentionally empty. The named type appears in IDE completions,
+// method signatures, and docs in a way that `Response<AccountCreateReceipt>` does not. All
+// transaction-specific data lives on AccountCreateReceipt, not here.
+AccountCreateResponse extends transactions.Response<AccountCreateReceipt> {
 }
 
 @@finalType
+// Extends the base Receipt with the account ID assigned by the consensus node.
+// This is the only new field: everything else (status, exchangeRate, etc.) lives on Receipt.
 AccountCreateReceipt extends transactions.Receipt {
-    @@immutable accountId:common.AccountId
-}
-
-@@finalType
-AccountCreateRecord extends transactions.Record<AccountCreateReceipt> {
-    @@immutable accountId:common.AccountId
+    @@immutable accountId: common.AccountId
 }
 
 ```
@@ -41,6 +41,7 @@ AccountCreateRecord extends transactions.Record<AccountCreateReceipt> {
 ### Simple flow
 
 Creates a new account with a balance of 100 hbars using `buildAndExecute` for a single-signer flow.
+The return type is `AccountCreateResponse` — no cast or extraction needed.
 
 ```
 HieroClient client = ...
@@ -56,13 +57,14 @@ AccountId newAccountId = response.queryReceipt().getAccountId();
 
 ### Multi-party signing
 
-Creates a new account where both the operator and another party need to sign.
+Creates a new account where both the operator and another party need to sign. Because `build()` returns
+`Transaction<AccountCreateResponse>`, the typed response is preserved through the signing chain.
 
 ```
 HieroClient client = ...
 PublicKey keyOfNewAccount = ...
 
-Transaction tx = new AccountCreateTransactionBuilder()
+Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
     .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
     .build(client);

--- a/v3-sandbox/prototype-api/transactions-accounts.md
+++ b/v3-sandbox/prototype-api/transactions-accounts.md
@@ -14,15 +14,11 @@ namespace transactions-accounts
 requires common, transactions, keys
 
 @@finalType
-AccountCreateTransactionBuilder extends transactions.TransactionBuilder<AccountCreateTransactionBuilder, AccountCreateResponse> {
+AccountCreateTransactionBuilder extends transactions.TransactionBuilder<AccountCreateTransactionBuilder, transactions.Response<AccountCreateReceipt>> {
     @@nullable accountMemo: string
     @@default(0) initialBalance: common.Hbar
     key: keys.PublicKey
 }
-
-// Named alias for ergonomics. Appears in IDE completions, method signatures, and docs in a way that
-// Response<AccountCreateReceipt> does not. All transaction-specific data lives on AccountCreateReceipt.
-@@alias AccountCreateResponse = transactions.Response<AccountCreateReceipt>
 
 @@finalType
 // Extends the base Receipt with the account ID assigned by the consensus node.
@@ -38,13 +34,12 @@ AccountCreateReceipt extends transactions.Receipt {
 ### Simple flow
 
 Creates a new account with a balance of 100 hbars using `buildAndExecute` for a single-signer flow.
-The return type is `AccountCreateResponse` — no cast or extraction needed.
 
 ```
 HieroClient client = ...
 PublicKey keyOfNewAccount = ...
 
-AccountCreateResponse response = new AccountCreateTransactionBuilder()
+Response<AccountCreateReceipt> response = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
     .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
     .buildAndExecute(client);
@@ -55,13 +50,13 @@ AccountId newAccountId = response.queryReceipt().getAccountId();
 ### Multi-party signing
 
 Creates a new account where both the operator and another party need to sign. Because `build()` returns
-`Transaction<AccountCreateResponse>`, the typed response is preserved through the signing chain.
+`Transaction<Response<AccountCreateReceipt>>`, the typed response is preserved through the signing chain.
 
 ```
 HieroClient client = ...
 PublicKey keyOfNewAccount = ...
 
-Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()
+Transaction<Response<AccountCreateReceipt>> tx = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
     .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
     .build(client);
@@ -69,7 +64,7 @@ Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()
 tx.sign(operatorKey);
 tx.sign(otherPartyKey);
 
-AccountCreateResponse response = tx.execute(client);
+Response<AccountCreateReceipt> response = tx.execute(client);
 AccountId newAccountId = response.queryReceipt().getAccountId();
 ```
 

--- a/v3-sandbox/prototype-api/transactions-accounts.md
+++ b/v3-sandbox/prototype-api/transactions-accounts.md
@@ -20,12 +20,9 @@ AccountCreateTransactionBuilder extends transactions.TransactionBuilder<AccountC
     key: keys.PublicKey
 }
 
-@@finalType
-// Named response type for ergonomics — intentionally empty. The named type appears in IDE completions,
-// method signatures, and docs in a way that `Response<AccountCreateReceipt>` does not. All
-// transaction-specific data lives on AccountCreateReceipt, not here.
-AccountCreateResponse extends transactions.Response<AccountCreateReceipt> {
-}
+// Named alias for ergonomics. Appears in IDE completions, method signatures, and docs in a way that
+// Response<AccountCreateReceipt> does not. All transaction-specific data lives on AccountCreateReceipt.
+@@alias AccountCreateResponse = transactions.Response<AccountCreateReceipt>
 
 @@finalType
 // Extends the base Receipt with the account ID assigned by the consensus node.

--- a/v3-sandbox/prototype-api/transactions-spi.md
+++ b/v3-sandbox/prototype-api/transactions-spi.md
@@ -18,8 +18,11 @@ In the `TransactionBuilder`/`Transaction` model, the domain-specific type is the
 namespace transactions-spi
 requires transactions, grpc, hiero-proto
 
-// TransactionSupport is the interface that must be implemented per custom transaction type
-abstraction TransactionSupport<$$TransactionBuilder, $$Response, $$Receipt, $$Record> {
+// TransactionSupport is the interface that must be implemented per custom transaction type.
+// $$Record is intentionally absent as a generic parameter: records are always the universal
+// Record<$$Receipt> type with no named subtypes. The convert method below returns Record<$$Receipt>
+// directly — see the "Design Rationale" section of transactions.md for the reasoning.
+abstraction TransactionSupport<$$TransactionBuilder, $$Response, $$Receipt> {
 
     type getTransactionType() // defines the transaction builder type ($$TransactionBuilder) the concrete TransactionSupport implementation supports
 
@@ -33,7 +36,7 @@ abstraction TransactionSupport<$$TransactionBuilder, $$Response, $$Receipt, $$Re
 
     $$Receipt convert(protoReceipt:hiero-proto.TransactionReceipt) // converts a proto TransactionReceipt to a Receipt
 
-    $$Record convert(protoRecord:hiero-proto.TransactionRecord) // converts a proto TransactionRecord to a Record
+    transactions.Record<$$Receipt> convert(protoRecord:hiero-proto.TransactionRecord) // converts a proto TransactionRecord to a Record
 }
 
 // factory methods that need to be implemented

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -237,38 +237,38 @@ specific transaction type. After creating an account, for example, the user must
 and accept that all other fields are null. The compiler cannot help, and documentation cannot fully
 substitute for type safety.
 
-### Why receipts are typed (risk: ~5%)
+### Why receipts are typed
 
-The concern with per-type receipts is that a future protocol change could add a field to an existing
-transaction type that previously had no typed receipt — changing its `queryReceipt()` return type, which is
-a breaking change in languages without subtype polymorphism (Go, Rust).
+The concern with per-type receipts is that a future protocol change could add a receipt field to an
+existing transaction type that previously had no typed receipt, changing its `queryReceipt()` return type.
+This is a real risk and the decision to use typed receipts should be revisited with broader community input
+before V3 is finalized.
 
-An analysis of the actual `transaction_receipt.proto` evolution across 7 years of mainnet history shows
-this risk is effectively theoretical:
+That said, the historical evidence from `transaction_receipt.proto` across 7 years of mainnet is
+encouraging:
 
 - Every new receipt field introduced since genesis has been tied to a **new transaction type** (HCS, HTS,
   scheduled transactions, NFTs, node management, etc.).
-- The only cross-cutting addition — `block_number` (added Mar 2026, block stream work) — applies to
-  **all** transactions and therefore lives on the base `Receipt` type. It does not affect any typed receipt
-  subtype.
-- There is no historical precedent for an existing "action" transaction (CryptoTransfer, AccountUpdate,
-  TokenBurn, etc.) gaining a receipt-specific field.
+- The one cross-cutting addition — `block_number` (added Mar 2026, block stream work) — applies to
+  **all** transactions and therefore lives on the base `Receipt` type. It does not require changes to any
+  typed receipt subtype.
+- There is no historical precedent for an existing transaction type that returns only a base `Receipt`
+  gaining a transaction-specific receipt field after the fact.
 
 This pattern holds because the receipt's purpose is narrow: "what entity was created, and did it succeed?"
-That question is answered at the time a transaction type is designed, not later.
+That question is answered at the time a transaction type is designed, not later. The set of transactions
+needing typed receipts is listed below and should be treated as a working draft pending broader review.
 
-Typed receipts are therefore safe, and the set of transactions that need them is effectively closed to the
-entity-creating transactions listed below.
-
-### Why responses are named (risk: ~3%)
+### Why responses are named
 
 The protobuf `TransactionResponse` — the immediate gRPC reply from the consensus node — has exactly two
 fields (`nodeTransactionPrecheckCode`, `cost`) and has had **zero structural changes** in 7+ years of
-mainnet. It is a pure pre-consensus acknowledgement: "the node received your transaction and will gossip it."
-There is no transaction-specific data in it and there never has been. The risk of named SDK `Response`
-subtypes causing breaking changes from protocol evolution is negligible.
+mainnet. It is a pure pre-consensus acknowledgement: "the node received your transaction and will gossip
+it." There is no transaction-specific data in it and there never has been. The risk of named SDK `Response`
+aliases causing breaking changes from protocol evolution is low, though the same caution applied to typed
+receipts applies here as well.
 
-Named response subtypes exist purely for ergonomics. There is a meaningful difference between a *structural
+Named response aliases exist for ergonomics. There is a meaningful difference between a *structural
 description* and a *name*:
 
 ```
@@ -276,26 +276,21 @@ Response<AccountCreateReceipt> response = builder.buildAndExecute(client);  // s
 AccountCreateResponse response = builder.buildAndExecute(client);           // named, clear intent
 ```
 
-The named type appears in IDE completions, method signatures, error messages, and documentation in a way
-that immediately tells the user what kind of operation produced it. In Rust and Swift, it also enables
-type-based dispatch and pattern matching. The block stream `TransactionOutput` proto independently arrived
-at the same conclusion — a `oneof` with named per-transaction outputs — and while it pruned some variants
-that turned out redundant, it did not abandon the named-type approach.
+The named type appears in call sites, method signatures, error messages, and documentation in a way that
+immediately tells the user what kind of operation produced it.
 
-Named `Response` subtypes **must remain empty** (no fields). All transaction-specific data lives on the
-typed `Receipt` or the universal `Record`. Adding any fields to a `Response` subtype would be wrong —
-the `Response`'s only job is to carry the transaction ID and provide the async poll methods.
+Response types are declared using `@@alias` (see `guides/api-guideline.md`), which communicates that these
+are names for parameterizations of `Response<$$Receipt>` rather than distinct type extensions. See each
+language's best practice guide for the implementation pattern.
 
-Response types are declared using `@@alias` (defined in `guides/api-guideline.md`). This correctly
-communicates that these are names for parameterizations of `Response<$$Receipt>`, not distinct type
-extensions. Language implementations translate `@@alias` to their native alias mechanism where available;
-languages without one (Java) use an empty final class. See each language's best practice guide for the
-exact pattern.
+Named response aliases **must have no fields or methods**. All transaction-specific data lives on the
+typed `Receipt` or the universal `Record`. The `Response`'s only job is to carry the transaction ID and
+provide the async poll methods.
 
-Every transaction type gets a named response, including action transactions. For entity-creating
-transactions the response is parameterized with a typed receipt (`AccountCreateResponse` →
-`Response<AccountCreateReceipt>`). For action transactions it is parameterized with the base receipt
-(`AccountUpdateResponse` → `Response<Receipt>`). Either way the user gets a named type.
+Every transaction type gets a named response alias. Transactions with receipt-specific output are
+parameterized with a typed receipt (`AccountCreateResponse` = `Response<AccountCreateReceipt>`).
+Transactions without are parameterized with the base receipt (`AccountUpdateResponse` = `Response<Receipt>`).
+Either way the user gets a named type.
 
 ### Why records are NOT typed (risk: ~60%)
 
@@ -308,8 +303,8 @@ across subsets of **existing** transaction types:
   types today, with the subset expected to expand over time
 
 If named record subtypes existed for these transaction types, each expansion would change the
-`queryRecord()` return type for newly-affected transactions — a breaking change in Go and Rust.
-Even in Java and TypeScript, it would require updating all 7 SDKs in lockstep.
+`queryRecord()` return type for newly-affected transactions — a breaking change across all SDK
+implementations.
 
 The record is the protocol's extension surface. Protocol-specific record data belongs as nullable fields
 on the universal `Record<$$Receipt>` base type, not in named subtypes. This keeps additions non-breaking
@@ -328,9 +323,10 @@ by design.
 | TokenMint (NFT)          | `serials`, `totalSupply`                  |
 | TopicMessageSubmit       | `topicSequenceNumber`, `topicRunningHash` |
 
-All other transactions ("action" transactions: updates, deletes, transfers, burns, associates, etc.)
-still get a named `Response` subtype — see the rationale section above — but parameterized with the base
-`Receipt` rather than a typed one.
+Transactions not listed above — those whose receipts carry no transaction-specific output fields — still
+get a named `Response` alias but are parameterized with the base `Receipt` rather than a typed one. Note
+that this table is a working draft: which transactions belong here should be validated with broader
+community input before V3 is finalized.
 
 ### How to define a typed transaction in practice
 
@@ -350,7 +346,7 @@ FooReceipt extends transactions.Receipt {
 }
 ```
 
-For an action transaction (base receipt, named response):
+For a transaction with no receipt-specific output (base receipt, named response):
 
 ```
 @@finalType

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -285,4 +285,6 @@ BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuil
 ## Questions & Comments
 
 - [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch the operator for a HieroClient (e.g. testing), as well as the network it connects to. I don't necessarily see a benefit in enforcing @@immutable here for these types.
+- [@hendrikEbbers](https://github.com/hendrikebbers): Only because protobuf defined 1 generic record type we do not need to do it if we can provide a more simple/smaller/concreter scope/api to the app developer. Nothing we need to decide today. We should discuss pro/con of that
+- [@hendrikEbbers](https://github.com/hendrikebbers): It might make sense to have even for transaction types that does not add new attributes concrete implementations for Response/Receipt. Those classes could provide documentation and help in switch cases as example.
 - [@rwalworth](https://github.com/rwalworth) / [@0xivanov](https://github.com/0xivanov): Should maxTransactionFee and validDuration have default values?

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -236,8 +236,7 @@ transaction types over time — named record subtypes would produce breaking cha
 Named response aliases (`@@alias`) exist for ergonomics only and carry no fields or methods.
 
 **This is a working draft.** Typed receipts and responses carry real protocol-evolution risk and these
-decisions should be validated with broader community input before V3 is finalized. See the PR for the
-full analysis and open questions.
+decisions should be validated with broader community input before V3 is finalized.
 
 ### Transactions needing typed receipts
 

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -226,89 +226,18 @@ tx2.sign(walletKey);
 tx2.execute(walletClient);
 ```
 
-## Design Rationale: Typed Receipts, Universal Records
+## Design Rationale
 
-### The problem with a single base Receipt
+Receipts are typed per-transaction because the receipt's purpose is narrow ("what entity was created?")
+and 7 years of mainnet history show that receipt fields have always been introduced alongside new
+transaction types, never added to existing ones after the fact. Records are intentionally not typed
+because the `TransactionRecord` protobuf evolves with cross-cutting protocol features that expand to new
+transaction types over time — named record subtypes would produce breaking changes as that set grows.
+Named response aliases (`@@alias`) exist for ergonomics only and carry no fields or methods.
 
-The v2 SDKs use a single `TransactionReceipt` with roughly 15 optional/nullable fields — `accountId`,
-`fileId`, `contractId`, `topicId`, `tokenId`, `scheduleId`, `scheduledTransactionId`, `serials`,
-`topicSequenceNumber`, `topicRunningHash`, and more. Every field is nullable because it only applies to a
-specific transaction type. After creating an account, for example, the user must know to read `.accountId`
-and accept that all other fields are null. The compiler cannot help, and documentation cannot fully
-substitute for type safety.
-
-### Why receipts are typed
-
-The concern with per-type receipts is that a future protocol change could add a receipt field to an
-existing transaction type that previously had no typed receipt, changing its `queryReceipt()` return type.
-This is a real risk and the decision to use typed receipts should be revisited with broader community input
-before V3 is finalized.
-
-That said, the historical evidence from `transaction_receipt.proto` across 7 years of mainnet is
-encouraging:
-
-- Every new receipt field introduced since genesis has been tied to a **new transaction type** (HCS, HTS,
-  scheduled transactions, NFTs, node management, etc.).
-- The one cross-cutting addition — `block_number` (added Mar 2026, block stream work) — applies to
-  **all** transactions and therefore lives on the base `Receipt` type. It does not require changes to any
-  typed receipt subtype.
-- There is no historical precedent for an existing transaction type that returns only a base `Receipt`
-  gaining a transaction-specific receipt field after the fact.
-
-This pattern holds because the receipt's purpose is narrow: "what entity was created, and did it succeed?"
-That question is answered at the time a transaction type is designed, not later. The set of transactions
-needing typed receipts is listed below and should be treated as a working draft pending broader review.
-
-### Why responses are named
-
-The protobuf `TransactionResponse` — the immediate gRPC reply from the consensus node — has exactly two
-fields (`nodeTransactionPrecheckCode`, `cost`) and has had **zero structural changes** in 7+ years of
-mainnet. It is a pure pre-consensus acknowledgement: "the node received your transaction and will gossip
-it." There is no transaction-specific data in it and there never has been. The risk of named SDK `Response`
-aliases causing breaking changes from protocol evolution is low, though the same caution applied to typed
-receipts applies here as well.
-
-Named response aliases exist for ergonomics. There is a meaningful difference between a *structural
-description* and a *name*:
-
-```
-Response<AccountCreateReceipt> response = builder.buildAndExecute(client);  // structural, verbose
-AccountCreateResponse response = builder.buildAndExecute(client);           // named, clear intent
-```
-
-The named type appears in call sites, method signatures, error messages, and documentation in a way that
-immediately tells the user what kind of operation produced it.
-
-Response types are declared using `@@alias` (see `guides/api-guideline.md`), which communicates that these
-are names for parameterizations of `Response<$$Receipt>` rather than distinct type extensions. See each
-language's best practice guide for the implementation pattern.
-
-Named response aliases **must have no fields or methods**. All transaction-specific data lives on the
-typed `Receipt` or the universal `Record`. The `Response`'s only job is to carry the transaction ID and
-provide the async poll methods.
-
-Every transaction type gets a named response alias. Transactions with receipt-specific output are
-parameterized with a typed receipt (`AccountCreateResponse` = `Response<AccountCreateReceipt>`).
-Transactions without are parameterized with the base receipt (`AccountUpdateResponse` = `Response<Receipt>`).
-Either way the user gets a named type.
-
-### Why records are NOT typed
-
-The `TransactionRecord` protobuf tells a different story. Its fields evolve with protocol features that cut
-across subsets of **existing** transaction types:
-
-- `assessed_custom_fees` (field 13) — applies to CryptoTransfer and token transfers
-- `paid_staking_rewards` (field 18) — applies to practically every transaction that adjusts stake
-- `high_volume_pricing_multiplier` (field 23, added Feb 2026, HIP-1313) — applies to ~14 transaction
-  types today, with the subset expected to expand over time
-
-If named record subtypes existed for these transaction types, each expansion would change the
-`queryRecord()` return type for newly-affected transactions — a breaking change across all SDK
-implementations.
-
-The record is the protocol's extension surface. Protocol-specific record data belongs as nullable fields
-on the universal `Record<$$Receipt>` base type, not in named subtypes. This keeps additions non-breaking
-by design.
+**This is a working draft.** Typed receipts and responses carry real protocol-evolution risk and these
+decisions should be validated with broader community input before V3 is finalized. See the PR for the
+full analysis and open questions.
 
 ### Transactions needing typed receipts
 
@@ -355,6 +284,7 @@ BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuil
 }
 
 @@alias BazResponse = transactions.Response<transactions.Receipt>
+```
 
 ## Questions & Comments
 

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -292,7 +292,7 @@ parameterized with a typed receipt (`AccountCreateResponse` = `Response<AccountC
 Transactions without are parameterized with the base receipt (`AccountUpdateResponse` = `Response<Receipt>`).
 Either way the user gets a named type.
 
-### Why records are NOT typed (risk: ~60%)
+### Why records are NOT typed
 
 The `TransactionRecord` protobuf tells a different story. Its fields evolve with protocol features that cut
 across subsets of **existing** transaction types:

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -50,9 +50,13 @@ abstraction TransactionSigner {
 }
 
 // Mutable builder for constructing a transaction body. Concrete transaction builders extend this
-// with domain-specific setters. The generic parameter is self-referential (CRTP) to enable fluent
-// setter chains that return the concrete builder type.
-abstraction TransactionBuilder<$$Transaction extends TransactionBuilder, $$Response extends Response> {
+// with domain-specific setters.
+//
+// Two generic parameters:
+//   $$Builder  — self-referential (CRTP) so fluent setter chains return the concrete builder type.
+//   $$Response — the typed response produced by this transaction. Use Response<Receipt>
+//                for transactions that do not add entity-specific receipt fields.
+abstraction TransactionBuilder<$$Builder extends TransactionBuilder, $$Response extends Response> {
   @@nullable maxTransactionFee: common.Hbar
   @@nullable validDuration: long
   @@nullable memo: string
@@ -62,69 +66,91 @@ abstraction TransactionBuilder<$$Transaction extends TransactionBuilder, $$Respo
   // Transitions from build phase to sign/send phase. If a client is provided, transactionId and
   // nodeAccountIds are auto-generated from the client. If no client is provided, they are left
   // unset (for flows like HIP-745 where incomplete transactions are serialized).
-  Transaction build(@@nullable client: client.HieroClient)
+  Transaction<$$Response> build(@@nullable client: client.HieroClient)
 
   // Convenience for simple single-signer flows. Requires a client. Internally does:
   // build(client) -> sign(client.operator) -> execute(client)
   @@async
-  $$Response buildAndExecute(client:client.HieroClient)
+  $$Response buildAndExecute(client: client.HieroClient)
 }
 
 // An immutable transaction ready for signing, serialization, and submission. The transaction body
 // cannot be modified after build — only network execution config and signatures can be added.
+//
+// The generic parameter $$Response carries the typed response produced when the transaction is
+// executed. This ensures that the typed return value is preserved through the full
+// build() → sign() → execute() chain, including multi-party signing flows.
 @@finalType
-Transaction {
+Transaction<$$Response extends Response> {
   // Network execution config — does not affect the signed transaction body
-  @@nullable maxAttempts:int32
-  @@nullable maxBackoff:long
-  @@nullable minBackoff:long
-  @@nullable attemptTimeout:long
-  
-  // Sign the transaction with the given key pair
-  Transaction sign(keyPair: keys.KeyPair)
-  
-  // Sign the transaction using an external signer
-  Transaction sign(publicKey: keys.PublicKey, transactionSigner: TransactionSigner) 
+  @@nullable maxAttempts: int32
+  @@nullable maxBackoff: long
+  @@nullable minBackoff: long
+  @@nullable attemptTimeout: long
+
+  // Sign the transaction with the given key pair. Returns self to allow chaining.
+  Transaction<$$Response> sign(keyPair: keys.KeyPair)
+
+  // Sign the transaction using an external signer. Returns self to allow chaining.
+  Transaction<$$Response> sign(publicKey: keys.PublicKey, transactionSigner: TransactionSigner)
 
   // Returns the signatures that have been added to this transaction, keyed by node account id and public key
   map<common.AccountId, map<keys.PublicKey, bytes>> getSignatures()
 
-  // Submit the transaction to the network and return the response
+  // Submit the transaction to the network and return the typed response
   @@async
-  Response execute(client:client.HieroClient)
+  $$Response execute(client: client.HieroClient)
 
   // Serialize the transaction (including signatures) to bytes
-  bytes toBytes() 
-  
-  // Deserialize a transaction from bytes
-  @@static
-  Transaction fromBytes(transactionBytes: bytes)
+  bytes toBytes()
 
-  // Returns a mutable builder pre-populated with this transaction's body.
+  // Deserialize a transaction from bytes. Returns a raw Transaction<Response> because the response
+  // type cannot be inferred from bytes alone. If the transaction type is known at the call site
+  // (e.g. in a multi-party signing flow), language implementations may provide typed overloads
+  // or allow an explicit cast to the expected Transaction<$$Response>.
+  @@static
+  Transaction<Response> fromBytes(transactionBytes: bytes)
+
+  // Returns a mutable builder pre-populated with this transaction's body. Because Transaction is
+  // generic but TransactionBuilder requires two type parameters (the concrete builder type is not
+  // recoverable from bytes alone), this returns the base TransactionBuilder. Callers that know
+  // the concrete builder type may cast to it.
   TransactionBuilder unbuild()
 }
 
-// The response of a transaction execution
-Response<$$Receipt extends Receipt, $$Record extends Record> {
-  @@immutable transactionId:TransactionId // the id of the transaction
+// The response of a transaction execution. Parameterized by the typed receipt only.
+//
+// Records are NOT parameterized here by design: the TransactionRecord protobuf evolves with
+// cross-cutting protocol features (assessed_custom_fees, paid_staking_rewards,
+// high_volume_pricing_multiplier, etc.) that apply to subsets of existing transaction types and
+// expand over time. Named record subtypes would create breaking changes whenever a new protocol
+// feature extends to additional transaction types. queryRecord() therefore always returns the
+// universal Record<$$Receipt>, with nullable fields on the base Record for protocol-specific data.
+//
+// See the "Design Rationale" section for the full analysis.
+Response<$$Receipt extends Receipt> {
+  @@immutable transactionId: TransactionId // the id of the transaction
 
-  @@async $$Receipt queryReceipt() // query for the receipt of the transaction
-  @@async $$Record queryRecord() // query for the record of the transaction
+  @@async $$Receipt queryReceipt()          // query for the receipt of the transaction
+  @@async Record<$$Receipt> queryRecord()   // query for the record of the transaction
 }
 
-// The receipt of a transaction
+// The receipt of a transaction. Subtype this only when the transaction creates an entity or
+// returns meaningful data in the receipt (e.g. AccountCreate → accountId, TokenMint → serials).
+// For all other transactions, use this base type directly.
 Receipt {
-  @@immutable transactionId:TransactionId // the id of the transaction
-  @@immutable status:TransactionStatus // the status of the transaction
-  @@immutable exchangeRate:common.HBarExchangeRate // the exchange rate at the time of the transaction
-  @@immutable nextExchangeRate:common.HBarExchangeRate // the next exchange rate
+  @@immutable transactionId: TransactionId     // the id of the transaction
+  @@immutable status: TransactionStatus        // the status of the transaction
+  @@immutable exchangeRate: common.HBarExchangeRate     // the exchange rate at the time of the transaction
+  @@immutable nextExchangeRate: common.HBarExchangeRate // the next exchange rate
 }
 
-// The record of a transaction
+// The record of a transaction. Named subtypes of Record are intentionally not used — see the
+// "Design Rationale" section. All protocol-specific record fields are nullable on this base type.
 Record<$$Receipt extends Receipt> {
-  @@immutable transactionId:TransactionId // the id of the transaction
-  @@immutable consensusTimestamp:zonedDateTime // the consensus time of the transaction
-  @@immutable receipt:$$Receipt // the receipt of the transaction
+  @@immutable transactionId: TransactionId          // the id of the transaction
+  @@immutable consensusTimestamp: zonedDateTime      // the consensus time of the transaction
+  @@immutable receipt: $$Receipt                     // the typed receipt of the transaction
 }
 
 // Factory methods for TransactionId
@@ -138,11 +164,12 @@ TransactionId generateTransactionId(accountId:common.AccountId)
 ### Simple flow (single signer)
 
 The most common case. `buildAndExecute` handles build, signing with the client operator, and execution in one call.
+The typed response is inferred directly from the builder's `$$Response` parameter.
 
 ```
 HieroClient client = ...
 
-Response response = new FooTransactionBuilder()
+FooResponse response = new FooTransactionBuilder()
     .setBar("baz")
     .buildAndExecute(client);
 
@@ -151,34 +178,40 @@ FooReceipt receipt = response.queryReceipt();
 
 ### Multi-party signing
 
-For transactions requiring multiple signatures. `build(client)` auto-generates `transactionId` and `nodeAccountIds`, then the transaction is serialized and sent to other parties for signing.
+For transactions requiring multiple signatures. `build(client)` returns a `Transaction<$$Response>`, preserving the
+typed response through the signing chain. This is the key benefit of the generic parameter on `Transaction`.
 
 ```
 HieroClient client = ...
 
-// Alice builds and signs
-Transaction tx = new TransferTransactionBuilder()
-    .addTransfer(alice, Hbar.from(-5))
-    .addTransfer(bob, Hbar.from(5))
+// Alice builds — Transaction<AccountCreateResponse> carries the type forward
+Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()
+    .setKey(keyOfNewAccount)
+    .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
     .build(client);
 
 tx.sign(aliceKey);
 bytes txBytes = tx.toBytes();
 // send txBytes to Bob
 
-// Bob receives, signs, executes
-Transaction tx2 = Transaction.fromBytes(txBytes);
+// Bob receives and signs. fromBytes() returns Transaction<Response> (raw — type cannot be inferred
+// from bytes). Because Bob knows the transaction type out of band, he may cast explicitly.
+Transaction<AccountCreateResponse> tx2 = (Transaction<AccountCreateResponse>) Transaction.fromBytes(txBytes);
 tx2.sign(bobKey);
-Response response = tx2.execute(client);
+
+AccountCreateResponse response = tx2.execute(client);
+AccountId newAccountId = response.queryReceipt().getAccountId();
 ```
 
 ### HIP-745 (dApp to wallet, incomplete transaction)
 
-For flows where a dApp builds a transaction without a transactionId or nodeAccountIds and sends it to a wallet for completion.
+For flows where a dApp builds a transaction without a transactionId or nodeAccountIds and sends it to a wallet for
+completion. Both sides treat the transaction as raw (`Transaction<Response>`) because the wallet operates on
+arbitrary transaction types.
 
 ```
 // dApp builds without a client — no transactionId or nodeAccountIds generated
-Transaction tx = new TransferTransactionBuilder()
+Transaction<Response> tx = new TransferTransactionBuilder()
     .addTransfer(alice, Hbar.from(-10))
     .addTransfer(bob, Hbar.from(10))
     .build();
@@ -188,10 +221,144 @@ bytes txBytes = tx.toBytes();
 
 // Wallet receives, unbuilds to modify, then rebuilds with its own client
 TransactionBuilder builder = Transaction.fromBytes(txBytes).unbuild();
-Transaction tx2 = builder.build(walletClient);
+Transaction<Response> tx2 = builder.build(walletClient);
 tx2.sign(walletKey);
 tx2.execute(walletClient);
 ```
+
+## Design Rationale: Typed Receipts, Universal Records
+
+### The problem with a single base Receipt
+
+The v2 SDKs use a single `TransactionReceipt` with roughly 15 optional/nullable fields — `accountId`,
+`fileId`, `contractId`, `topicId`, `tokenId`, `scheduleId`, `scheduledTransactionId`, `serials`,
+`topicSequenceNumber`, `topicRunningHash`, and more. Every field is nullable because it only applies to a
+specific transaction type. After creating an account, for example, the user must know to read `.accountId`
+and accept that all other fields are null. The compiler cannot help, and documentation cannot fully
+substitute for type safety.
+
+### Why receipts are typed (risk: ~5%)
+
+The concern with per-type receipts is that a future protocol change could add a field to an existing
+transaction type that previously had no typed receipt — changing its `queryReceipt()` return type, which is
+a breaking change in languages without subtype polymorphism (Go, Rust).
+
+An analysis of the actual `transaction_receipt.proto` evolution across 7 years of mainnet history shows
+this risk is effectively theoretical:
+
+- Every new receipt field introduced since genesis has been tied to a **new transaction type** (HCS, HTS,
+  scheduled transactions, NFTs, node management, etc.).
+- The only cross-cutting addition — `block_number` (added Mar 2026, block stream work) — applies to
+  **all** transactions and therefore lives on the base `Receipt` type. It does not affect any typed receipt
+  subtype.
+- There is no historical precedent for an existing "action" transaction (CryptoTransfer, AccountUpdate,
+  TokenBurn, etc.) gaining a receipt-specific field.
+
+This pattern holds because the receipt's purpose is narrow: "what entity was created, and did it succeed?"
+That question is answered at the time a transaction type is designed, not later.
+
+Typed receipts are therefore safe, and the set of transactions that need them is effectively closed to the
+entity-creating transactions listed below.
+
+### Why responses are named (risk: ~3%)
+
+The protobuf `TransactionResponse` — the immediate gRPC reply from the consensus node — has exactly two
+fields (`nodeTransactionPrecheckCode`, `cost`) and has had **zero structural changes** in 7+ years of
+mainnet. It is a pure pre-consensus acknowledgement: "the node received your transaction and will gossip it."
+There is no transaction-specific data in it and there never has been. The risk of named SDK `Response`
+subtypes causing breaking changes from protocol evolution is negligible.
+
+Named response subtypes exist purely for ergonomics. There is a meaningful difference between a *structural
+description* and a *name*:
+
+```
+Response<AccountCreateReceipt> response = builder.buildAndExecute(client);  // structural, verbose
+AccountCreateResponse response = builder.buildAndExecute(client);           // named, clear intent
+```
+
+The named type appears in IDE completions, method signatures, error messages, and documentation in a way
+that immediately tells the user what kind of operation produced it. In Rust and Swift, it also enables
+type-based dispatch and pattern matching. The block stream `TransactionOutput` proto independently arrived
+at the same conclusion — a `oneof` with named per-transaction outputs — and while it pruned some variants
+that turned out redundant, it did not abandon the named-type approach.
+
+Named `Response` subtypes **must remain empty** (no fields). All transaction-specific data lives on the
+typed `Receipt` or the universal `Record`. Adding any fields to a `Response` subtype would be wrong —
+the `Response`'s only job is to carry the transaction ID and provide the async poll methods.
+
+Every transaction type gets a named response, including action transactions. For entity-creating
+transactions the response is parameterized with a typed receipt (`AccountCreateResponse` →
+`Response<AccountCreateReceipt>`). For action transactions it is parameterized with the base receipt
+(`AccountUpdateResponse` → `Response<Receipt>`). Either way the user gets a named type.
+
+### Why records are NOT typed (risk: ~60%)
+
+The `TransactionRecord` protobuf tells a different story. Its fields evolve with protocol features that cut
+across subsets of **existing** transaction types:
+
+- `assessed_custom_fees` (field 13) — applies to CryptoTransfer and token transfers
+- `paid_staking_rewards` (field 18) — applies to practically every transaction that adjusts stake
+- `high_volume_pricing_multiplier` (field 23, added Feb 2026, HIP-1313) — applies to ~14 transaction
+  types today, with the subset expected to expand over time
+
+If named record subtypes existed for these transaction types, each expansion would change the
+`queryRecord()` return type for newly-affected transactions — a breaking change in Go and Rust.
+Even in Java and TypeScript, it would require updating all 7 SDKs in lockstep.
+
+The record is the protocol's extension surface. Protocol-specific record data belongs as nullable fields
+on the universal `Record<$$Receipt>` base type, not in named subtypes. This keeps additions non-breaking
+by design.
+
+### Transactions needing typed receipts
+
+| Transaction              | New receipt field(s)                      |
+|--------------------------|-------------------------------------------|
+| AccountCreate            | `accountId`                               |
+| FileCreate               | `fileId`                                  |
+| ContractCreate           | `contractId`                              |
+| TopicCreate              | `topicId`                                 |
+| TokenCreate              | `tokenId`                                 |
+| ScheduleCreate           | `scheduleId`, `scheduledTransactionId`    |
+| TokenMint (NFT)          | `serials`, `totalSupply`                  |
+| TopicMessageSubmit       | `topicSequenceNumber`, `topicRunningHash` |
+
+All other transactions ("action" transactions: updates, deletes, transfers, burns, associates, etc.)
+still get a named `Response` subtype — see the rationale section above — but parameterized with the base
+`Receipt` rather than a typed one.
+
+### How to define a typed transaction in practice
+
+For a transaction that creates an entity (typed receipt, named response):
+
+```
+@@finalType
+FooTransactionBuilder extends transactions.TransactionBuilder<FooTransactionBuilder, FooResponse> {
+    // domain-specific fields
+}
+
+@@finalType
+// Named for ergonomics — must remain empty. All entity-specific data is on FooReceipt.
+FooResponse extends transactions.Response<FooReceipt> {
+}
+
+@@finalType
+FooReceipt extends transactions.Receipt {
+    @@immutable fooId: common.FooId  // the only new field
+}
+```
+
+For an action transaction (base receipt, named response):
+
+```
+@@finalType
+BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuilder, BazResponse> {
+    // domain-specific fields
+}
+
+@@finalType
+// Named for ergonomics — must remain empty. Base Receipt is sufficient; no entity-specific data.
+BazResponse extends transactions.Response<transactions.Receipt> {
+}
 
 ## Questions & Comments
 

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -286,6 +286,12 @@ Named `Response` subtypes **must remain empty** (no fields). All transaction-spe
 typed `Receipt` or the universal `Record`. Adding any fields to a `Response` subtype would be wrong —
 the `Response`'s only job is to carry the transaction ID and provide the async poll methods.
 
+Response types are declared using `@@alias` (defined in `guides/api-guideline.md`). This correctly
+communicates that these are names for parameterizations of `Response<$$Receipt>`, not distinct type
+extensions. Language implementations translate `@@alias` to their native alias mechanism where available;
+languages without one (Java) use an empty final class. See each language's best practice guide for the
+exact pattern.
+
 Every transaction type gets a named response, including action transactions. For entity-creating
 transactions the response is parameterized with a typed receipt (`AccountCreateResponse` →
 `Response<AccountCreateReceipt>`). For action transactions it is parameterized with the base receipt
@@ -336,10 +342,7 @@ FooTransactionBuilder extends transactions.TransactionBuilder<FooTransactionBuil
     // domain-specific fields
 }
 
-@@finalType
-// Named for ergonomics — must remain empty. All entity-specific data is on FooReceipt.
-FooResponse extends transactions.Response<FooReceipt> {
-}
+@@alias FooResponse = transactions.Response<FooReceipt>
 
 @@finalType
 FooReceipt extends transactions.Receipt {
@@ -355,10 +358,7 @@ BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuil
     // domain-specific fields
 }
 
-@@finalType
-// Named for ergonomics — must remain empty. Base Receipt is sufficient; no entity-specific data.
-BazResponse extends transactions.Response<transactions.Receipt> {
-}
+@@alias BazResponse = transactions.Response<transactions.Receipt>
 
 ## Questions & Comments
 

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -169,7 +169,7 @@ The typed response is inferred directly from the builder's `$$Response` paramete
 ```
 HieroClient client = ...
 
-FooResponse response = new FooTransactionBuilder()
+Response<FooReceipt> response = new FooTransactionBuilder()
     .setBar("baz")
     .buildAndExecute(client);
 
@@ -178,14 +178,14 @@ FooReceipt receipt = response.queryReceipt();
 
 ### Multi-party signing
 
-For transactions requiring multiple signatures. `build(client)` returns a `Transaction<$$Response>`, preserving the
+For transactions requiring multiple signatures. `build(client)` returns a `Transaction<Response<$$Receipt>>`, preserving the
 typed response through the signing chain. This is the key benefit of the generic parameter on `Transaction`.
 
 ```
 HieroClient client = ...
 
-// Alice builds — Transaction<AccountCreateResponse> carries the type forward
-Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()
+// Alice builds — Transaction<Response<AccountCreateReceipt>> carries the type forward
+Transaction<Response<AccountCreateReceipt>> tx = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
     .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
     .build(client);
@@ -196,10 +196,10 @@ bytes txBytes = tx.toBytes();
 
 // Bob receives and signs. fromBytes() returns Transaction<Response<Receipt>> (raw — type cannot be
 // inferred from bytes). Because Bob knows the transaction type out of band, he may cast explicitly.
-Transaction<AccountCreateResponse> tx2 = (Transaction<AccountCreateResponse>) Transaction.fromBytes(txBytes);
+Transaction<Response<AccountCreateReceipt>> tx2 = (Transaction<Response<AccountCreateReceipt>>) Transaction.fromBytes(txBytes);
 tx2.sign(bobKey);
 
-AccountCreateResponse response = tx2.execute(client);
+Response<AccountCreateReceipt> response = tx2.execute(client);
 AccountId newAccountId = response.queryReceipt().getAccountId();
 ```
 
@@ -233,7 +233,6 @@ and 7 years of mainnet history show that receipt fields have always been introdu
 transaction types, never added to existing ones after the fact. Records are intentionally not typed
 because the `TransactionRecord` protobuf evolves with cross-cutting protocol features that expand to new
 transaction types over time — named record subtypes would produce breaking changes as that set grows.
-Named response aliases (`@@alias`) exist for ergonomics only and carry no fields or methods.
 
 **This is a working draft.** Typed receipts and responses carry real protocol-evolution risk and these
 decisions should be validated with broader community input before V3 is finalized.
@@ -254,22 +253,19 @@ decisions should be validated with broader community input before V3 is finalize
 | NodeCreate               | `nodeId`                                                            |
 | TopicMessageSubmit       | `topicSequenceNumber`, `topicRunningHash`                           |
 
-Transactions not listed above — those whose receipts carry no transaction-specific output fields — still
-get a named `Response` alias but are parameterized with the base `Receipt` rather than a typed one. Note
-that this table is a working draft: which transactions belong here should be validated with broader
-community input before V3 is finalized.
+Transactions not listed above — those whose receipts carry no transaction-specific output fields — use
+`Response<Receipt>` directly. Note that this table is a working draft: which transactions belong here
+should be validated with broader community input before V3 is finalized.
 
 ### How to define a typed transaction in practice
 
-For a transaction that creates an entity (typed receipt, named response):
+For a transaction that creates an entity (typed receipt):
 
 ```
 @@finalType
-FooTransactionBuilder extends transactions.TransactionBuilder<FooTransactionBuilder, FooResponse> {
+FooTransactionBuilder extends transactions.TransactionBuilder<FooTransactionBuilder, transactions.Response<FooReceipt>> {
     // domain-specific fields
 }
-
-@@alias FooResponse = transactions.Response<FooReceipt>
 
 @@finalType
 FooReceipt extends transactions.Receipt {
@@ -277,15 +273,13 @@ FooReceipt extends transactions.Receipt {
 }
 ```
 
-For a transaction with no receipt-specific output (base receipt, named response):
+For a transaction with no receipt-specific output (base receipt):
 
 ```
 @@finalType
-BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuilder, BazResponse> {
+BazTransactionBuilder extends transactions.TransactionBuilder<BazTransactionBuilder, transactions.Response<transactions.Receipt>> {
     // domain-specific fields
 }
-
-@@alias BazResponse = transactions.Response<transactions.Receipt>
 ```
 
 ## Questions & Comments

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -104,12 +104,12 @@ Transaction<$$Response extends Response> {
   // Serialize the transaction (including signatures) to bytes
   bytes toBytes()
 
-  // Deserialize a transaction from bytes. Returns a raw Transaction<Response> because the response
+  // Deserialize a transaction from bytes. Returns Transaction<Response<Receipt>> because the response
   // type cannot be inferred from bytes alone. If the transaction type is known at the call site
   // (e.g. in a multi-party signing flow), language implementations may provide typed overloads
   // or allow an explicit cast to the expected Transaction<$$Response>.
   @@static
-  Transaction<Response> fromBytes(transactionBytes: bytes)
+  Transaction<Response<Receipt>> fromBytes(transactionBytes: bytes)
 
   // Returns a mutable builder pre-populated with this transaction's body. Because Transaction is
   // generic but TransactionBuilder requires two type parameters (the concrete builder type is not
@@ -194,8 +194,8 @@ tx.sign(aliceKey);
 bytes txBytes = tx.toBytes();
 // send txBytes to Bob
 
-// Bob receives and signs. fromBytes() returns Transaction<Response> (raw — type cannot be inferred
-// from bytes). Because Bob knows the transaction type out of band, he may cast explicitly.
+// Bob receives and signs. fromBytes() returns Transaction<Response<Receipt>> (raw — type cannot be
+// inferred from bytes). Because Bob knows the transaction type out of band, he may cast explicitly.
 Transaction<AccountCreateResponse> tx2 = (Transaction<AccountCreateResponse>) Transaction.fromBytes(txBytes);
 tx2.sign(bobKey);
 
@@ -206,12 +206,12 @@ AccountId newAccountId = response.queryReceipt().getAccountId();
 ### HIP-745 (dApp to wallet, incomplete transaction)
 
 For flows where a dApp builds a transaction without a transactionId or nodeAccountIds and sends it to a wallet for
-completion. Both sides treat the transaction as raw (`Transaction<Response>`) because the wallet operates on
+completion. Both sides treat the transaction as `Transaction<Response<Receipt>>` because the wallet operates on
 arbitrary transaction types.
 
 ```
 // dApp builds without a client — no transactionId or nodeAccountIds generated
-Transaction<Response> tx = new TransferTransactionBuilder()
+Transaction<Response<Receipt>> tx = new TransferTransactionBuilder()
     .addTransfer(alice, Hbar.from(-10))
     .addTransfer(bob, Hbar.from(10))
     .build();
@@ -221,7 +221,7 @@ bytes txBytes = tx.toBytes();
 
 // Wallet receives, unbuilds to modify, then rebuilds with its own client
 TransactionBuilder builder = Transaction.fromBytes(txBytes).unbuild();
-Transaction<Response> tx2 = builder.build(walletClient);
+Transaction<Response<Receipt>> tx2 = builder.build(walletClient);
 tx2.sign(walletKey);
 tx2.execute(walletClient);
 ```
@@ -240,16 +240,19 @@ decisions should be validated with broader community input before V3 is finalize
 
 ### Transactions needing typed receipts
 
-| Transaction              | New receipt field(s)                      |
-|--------------------------|-------------------------------------------|
-| AccountCreate            | `accountId`                               |
-| FileCreate               | `fileId`                                  |
-| ContractCreate           | `contractId`                              |
-| TopicCreate              | `topicId`                                 |
-| TokenCreate              | `tokenId`                                 |
-| ScheduleCreate           | `scheduleId`, `scheduledTransactionId`    |
-| TokenMint (NFT)          | `serials`, `totalSupply`                  |
-| TopicMessageSubmit       | `topicSequenceNumber`, `topicRunningHash` |
+| Transaction              | New receipt field(s)                                                |
+|--------------------------|---------------------------------------------------------------------|
+| AccountCreate            | `accountId`                                                         |
+| FileCreate               | `fileId`                                                            |
+| ContractCreate           | `contractId`                                                        |
+| TopicCreate              | `topicId`                                                           |
+| TokenCreate              | `tokenId`                                                           |
+| ScheduleCreate           | `scheduleId`, `scheduledTransactionId`                              |
+| TokenMint                | `newTotalSupply`; `@@nullable serials` (NFT mints only)             |
+| TokenBurn                | `newTotalSupply`                                                    |
+| TokenWipe                | `newTotalSupply`                                                    |
+| NodeCreate               | `nodeId`                                                            |
+| TopicMessageSubmit       | `topicSequenceNumber`, `topicRunningHash`                           |
 
 Transactions not listed above — those whose receipts carry no transaction-specific output fields — still
 get a named `Response` alias but are parameterized with the base `Receipt` rather than a typed one. Note


### PR DESCRIPTION
## Summary

This PR introduces per-transaction typed receipts and named response aliases to the V3 transaction API, while deliberately keeping records universal. It also adds `@@alias` to the meta-language and makes `Transaction` generic so the typed return value is preserved through the full build/sign/execute chain.

The core design positions are:

- **Typed receipts** — transactions that create entities (AccountCreate, TokenCreate, etc.) return a typed receipt subtype with only the fields relevant to that transaction, rather than a monolithic base type with 15 nullable fields.
- **Universal records** — records are intentionally not typed. The `TransactionRecord` protobuf evolves with cross-cutting protocol features that expand to new transaction types over time; named record subtypes would produce breaking changes as that set changes.
- **Named response aliases** — every transaction gets a named `@@alias` response type (e.g. `AccountCreateResponse`) for ergonomics at call sites, IDE completions, and documentation. These aliases carry no fields or methods.

> **Note:** The typed receipts and response aliases design carries real risk and should be validated with broader community input before V3 is finalized. See the design rationale section below.

---

## Motivation

The v2 `TransactionReceipt` contains roughly 15 optional/nullable fields — `accountId`, `fileId`, `contractId`, `topicId`, `tokenId`, `scheduleId`, `scheduledTransactionId`, `serials`, `topicSequenceNumber`, `topicRunningHash`, and more. Every field is nullable because it only applies to one specific transaction type. After creating an account, the user must know to read `.accountId` and accept that every other field is null. Static analysis cannot help, and documentation cannot fully substitute for type safety.

The v2 pattern also loses type information mid-chain. `buildAndExecute()` could theoretically return a typed value, but `build()` returns an untyped `Transaction` and `execute()` returns a bare `Response`, meaning the typed return value only existed at the first call site.

---

## Changes

### 1. Generic `Transaction<$$Response>` — type preserved through signing chains

`Transaction` is now parameterized by `$$Response`. `build()` returns `Transaction<$$Response>`, `sign()` returns `Transaction<$$Response>`, and `execute()` returns `@@async $$Response`. The typed return value now flows through the entire chain:

```
// Before: type lost after build()
Transaction tx = new AccountCreateTransactionBuilder()...build(client);
Response response = tx.execute(client);              // untyped

// After: type preserved
Transaction<AccountCreateResponse> tx = new AccountCreateTransactionBuilder()...build(client);
AccountCreateResponse response = tx.execute(client); // typed
```

`fromBytes()` returns `Transaction<Response>` (the raw base) because the response type cannot be inferred from bytes alone. Callers that know the transaction type may cast explicitly.

### 2. Typed receipts for entity-creating transactions

Transactions that return entity-specific data in the receipt get a named receipt subtype with only the relevant fields. All other fields (status, exchangeRate) remain on the base `Receipt`.

| Transaction        | New receipt field(s)                      |
|--------------------|-------------------------------------------|
| AccountCreate      | `accountId`                               |
| FileCreate         | `fileId`                                  |
| ContractCreate     | `contractId`                              |
| TopicCreate        | `topicId`                                 |
| TokenCreate        | `tokenId`                                 |
| ScheduleCreate     | `scheduleId`, `scheduledTransactionId`    |
| TokenMint (NFT)    | `serials`, `totalSupply`                  |
| TopicMessageSubmit | `topicSequenceNumber`, `topicRunningHash` |

Transactions not in this table use `Receipt` directly — no typed subtype, no new classes.

### 3. Named response aliases via `@@alias`

Every transaction gets a named response alias for ergonomics:

```
@@alias AccountCreateResponse = Response<AccountCreateReceipt>  // entity-creating
@@alias AccountUpdateResponse = Response<Receipt>               // no receipt-specific output
```

These aliases must remain empty — no fields, no methods. All transaction-specific data lives on the typed receipt. The alias exists solely so that call sites, IDE completions, error messages, and documentation show a meaningful name rather than the raw generic expression.

`@@alias` is a new construct added to the meta-language (`guides/api-guideline.md`). Each language's best practice guide specifies the implementation pattern.

### 4. Universal records — intentionally not typed

`Response.queryRecord()` returns `Record<$$Receipt>` directly. There are no named record subtypes. The `$$Record` type parameter is removed from `Response` entirely, simplifying it to a single parameter:

```
// Before
Response<$$Receipt extends Receipt, $$Record extends Record<$$Receipt>>

// After
Response<$$Receipt extends Receipt>
```

### 5. `TransactionSupport` SPI — `$$Record` parameter removed

`TransactionSupport` previously had four type parameters including `$$Record`. Since records are never typed, this parameter is removed. The `convert(protoRecord)` method now returns `transactions.Record<$$Receipt>` directly.

### 6. `@@alias` added to meta-language

`guides/api-guideline.md` now defines the `@@alias` construct:

```
@@alias AliasName = TargetType
```

Rules: no body, may refer to any type expression including generic instantiations, must not be used to introduce new behavior. Implementation pattern is delegated to each language's best practice guide.

---

## Design Rationale

### Why typed receipts (and why it's still a risk)

The primary concern with per-type receipts is protocol evolution: if a future HIP adds a receipt field to an existing transaction type that currently returns only a base `Receipt`, the `queryReceipt()` return type changes — a breaking change across all SDK implementations.

The historical evidence from `transaction_receipt.proto` is encouraging but not conclusive:

- Every new receipt field introduced since genesis has been tied to a **new transaction type** (HCS topics, HTS tokens, scheduled transactions, NFTs, node management, registered nodes).
- The one cross-cutting addition — `block_number` (field 17, Mar 2026) — applies to **all** transactions and therefore lives on the base `Receipt` type. It does not require changes to any typed subtype.
- There is no historical precedent for an existing transaction type that currently returns a base `Receipt` gaining a transaction-specific receipt field after the fact.

This pattern holds because the receipt's purpose is narrow: "what entity was created, and did it succeed?" That question is answered when a transaction type is designed, not through later protocol amendments. The risk is estimated to be low but it is real, and the typed receipts approach should be revisited with broader community input before V3 ships.

### Why records are not typed

The `TransactionRecord` protobuf tells a different story. Its fields evolve with protocol features that cut across subsets of **existing** transaction types:

- `assessed_custom_fees` (field 13) — added for CryptoTransfer and token transfers (existing tx types)
- `paid_staking_rewards` (field 18) — applies to practically every transaction that adjusts stake
- `high_volume_pricing_multiplier` (field 23, added Feb 2026, HIP-1313) — applies to ~14 existing transaction types today, with the set expected to expand with future HIPs

If named record subtypes existed, each expansion of these cross-cutting fields to additional transaction types would change `queryRecord()`'s return type for each newly-affected transaction — a breaking change across all SDK implementations. The record is the protocol's extension surface by design; typing it creates a maintenance trap that gets worse over time.

### Why responses are named aliases

The protobuf `TransactionResponse` — the immediate gRPC reply from the node — has exactly two fields and zero structural changes in 7+ years of mainnet. It is a pre-consensus acknowledgement only; no transaction-specific data has ever appeared in it.

Named response aliases exist purely for ergonomics. `AccountCreateResponse` in an IDE completion or error message is immediately meaningful; `Response<AccountCreateReceipt>` requires the reader to decode the type to understand it. The risk is low given the proto history, but the same caution applied to typed receipts applies here.

---

## Files Changed

| File | Change |
|------|--------|
| `guides/api-guideline.md` | Added `@@alias` type alias construct to the meta-language |
| `v3-sandbox/prototype-api/transactions.md` | Generic `Transaction<$$Response>`, simplified `Response<$$Receipt>`, design rationale summary, `@@alias` patterns |
| `v3-sandbox/prototype-api/transactions-accounts.md` | `AccountCreateTransactionBuilder` with both type params, `AccountCreateReceipt`, `@@alias AccountCreateResponse` |
| `v3-sandbox/prototype-api/transactions-spi.md` | Removed `$$Record` type parameter from `TransactionSupport` |

---

## Breaking Changes

**None** — this is a V3 prototype API definition. No existing SDK implementation is affected.

---

## Open Questions

These should be discussed before V3 is finalized:

1. **Typed receipts risk** — the historical evidence is encouraging but a single protocol change adding a receipt field to an existing non-entity-creating transaction would require breaking changes across all SDKs. Is the community comfortable with this trade-off, or should V3 stay with a universal `Receipt` and accept the v2 nullable-field DX problem?

2. **Which transactions need typed receipts** — the table in this PR is a working draft based on the current `transaction_receipt.proto` fields. It should be reviewed by SDK maintainers and the consensus node team to confirm completeness and accuracy.

3. **`@@alias` implementation pattern** — language-specific best practice guides need to define how `@@alias` maps to each language. For languages without native alias support, the fallback pattern must be specified.
