### PR TITLE
feat: add unsigned integer validation utility and usage guidelines

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -167,6 +167,139 @@ For each numeric Java type a maximum numeric type is defined.
 | `uint64`         | `long`, `java.lang.Long`   |
 | `uint256`        | `java.math.BigInteger`     |
 
+### Unsigned Integer Semantics
+
+Java does not have native unsigned integer types. The meta-language `uintX` types are mapped to signed Java primitives
+(`byte`, `short`, `int`, `long`), as shown in the table above. Because signed types can represent negative values that
+are invalid for unsigned fields, **explicit validation must be applied at every input boundary** (constructors, setters,
+builder methods, and parsing logic) to enforce correct unsigned semantics.
+
+**Valid ranges:**
+
+| Meta-Language Type | Java Type          | Valid Range                       |
+|--------------------|--------------------|-----------------------------------|
+| `uint8`            | `int`              | 0 to 255                         |
+| `uint16`           | `int`              | 0 to 65535                       |
+| `uint64`           | `long`             | 0 to `Long.MAX_VALUE`            |
+
+**Validation rules:**
+
+- If the value is negative, throw `IllegalArgumentException`.
+- If the value exceeds the maximum for the unsigned type, throw `IllegalArgumentException`.
+- Never silently clamp or transform values. Invalid inputs must be rejected immediately.
+- For `uint64`, Java's `long` cannot represent the full unsigned 64-bit range (0 to 2^64 - 1). The maximum
+  representable value is `Long.MAX_VALUE` (2^63 - 1). Any negative `long` value is invalid.
+
+**Utility class:**
+
+The SDK provides a `UnsignedValidator` utility class (see
+[UnsignedValidator.java](java-files/UnsignedValidator.java)) with static validation methods. These methods validate the
+input and return it unchanged, making them suitable for inline use in assignments:
+
+```java
+import org.hiero.sdk.validation.UnsignedValidator;
+
+public class ConsensusNode {
+
+    private final String ip;
+
+    private final int port; // uint16
+
+    private final long shard; // uint64
+
+    public ConsensusNode(@NonNull final String ip, final int port, final long shard) {
+        this.ip = Objects.requireNonNull(ip, "ip must not be null");
+        this.port = UnsignedValidator.requireUint16(port, "port");
+        this.shard = UnsignedValidator.requireUint64(shard, "shard");
+    }
+
+    @NonNull
+    public String getIp() {
+        return ip;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public long getShard() {
+        return shard;
+    }
+
+    public void setPort(final int port) {
+        this.port = UnsignedValidator.requireUint16(port, "port");
+    }
+}
+```
+
+**Inline validation without the utility class:**
+
+When the utility class is not available, validation can be performed directly. The pattern follows the same approach as
+`@@min`/`@@max` constraint validation:
+
+```java
+public void setPort(final int port) {
+    if (port < 0 || port > 65535) {
+        throw new IllegalArgumentException("port must be in the range 0 to 65535 (uint16), but was: " + port);
+    }
+    this.port = port;
+}
+
+public void setShard(final long shard) {
+    if (shard < 0) {
+        throw new IllegalArgumentException("shard must be non-negative (uint64), but was: " + shard);
+    }
+    this.shard = shard;
+}
+```
+
+**Builder pattern integration:**
+
+When a builder is used for a type containing unsigned fields, the builder setter methods should perform the
+validation so that invalid values are caught as early as possible:
+
+```java
+public static final class Builder {
+
+    private int port;
+
+    private long shard;
+
+    @NonNull
+    public Builder port(final int port) {
+        this.port = UnsignedValidator.requireUint16(port, "port");
+        return this;
+    }
+
+    @NonNull
+    public Builder shard(final long shard) {
+        this.shard = UnsignedValidator.requireUint64(shard, "shard");
+        return this;
+    }
+
+    @NonNull
+    public ConsensusNode build() {
+        return new ConsensusNode(this);
+    }
+}
+```
+
+**Record types:**
+
+For records mapped from types with unsigned fields, validation is performed in the compact constructor:
+
+```java
+public record Address(long shard, long realm, long num, @NonNull String checksum) {
+
+    public Address {
+        UnsignedValidator.requireUint64(shard, "shard");
+        UnsignedValidator.requireUint64(realm, "realm");
+        UnsignedValidator.requireUint64(num, "num");
+        Objects.requireNonNull(checksum, "checksum must not be null");
+    }
+}
+```
+
 ### Function Types
 
 The meta-language `function<R m(p: T, ...)>` maps to a `@FunctionalInterface` in Java. Where possible, use the

--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -169,12 +169,8 @@ For each numeric Java type a maximum numeric type is defined.
 
 ### Unsigned Integer Semantics
 
-Java does not have native unsigned integer types. The meta-language `uintX` types are mapped to signed Java primitives
-(`byte`, `short`, `int`, `long`), as shown in the table above. Because signed types can represent negative values that
-are invalid for unsigned fields, **explicit validation must be applied at every input boundary** (constructors, setters,
-builder methods, and parsing logic) to enforce correct unsigned semantics.
-
-**Valid ranges:**
+Java uses signed types for `uintX` mappings. Explicit validation must be applied at input boundaries to enforce
+unsigned semantics.
 
 | Meta-Language Type | Java Type          | Valid Range                       |
 |--------------------|--------------------|-----------------------------------|
@@ -184,11 +180,11 @@ builder methods, and parsing logic) to enforce correct unsigned semantics.
 
 **Validation rules:**
 
-- If the value is negative, throw `IllegalArgumentException`.
-- If the value exceeds the maximum for the unsigned type, throw `IllegalArgumentException`.
+- If the value is negative, throw `IllegalArgumentException("Value must be non-negative for unsigned types.")`.
+- If the value exceeds the maximum for the unsigned type, throw
+  `IllegalArgumentException("Value exceeds the allowed range for the unsigned type.")`.
 - Never silently clamp or transform values. Invalid inputs must be rejected immediately.
-- For `uint64`, Java's `long` cannot represent the full unsigned 64-bit range (0 to 2^64 - 1). The maximum
-  representable value is `Long.MAX_VALUE` (2^63 - 1). Any negative `long` value is invalid.
+- For `uint64`, Java's `long` cannot represent the full unsigned 64-bit range. Use `java.math.BigInteger`.
 
 **Utility class:**
 
@@ -229,27 +225,6 @@ public class ConsensusNode {
     public void setPort(final int port) {
         this.port = UnsignedValidator.requireUint16(port, "port");
     }
-}
-```
-
-**Inline validation without the utility class:**
-
-When the utility class is not available, validation can be performed directly. The pattern follows the same approach as
-`@@min`/`@@max` constraint validation:
-
-```java
-public void setPort(final int port) {
-    if (port < 0 || port > 65535) {
-        throw new IllegalArgumentException("port must be in the range 0 to 65535 (uint16), but was: " + port);
-    }
-    this.port = port;
-}
-
-public void setShard(final long shard) {
-    if (shard < 0) {
-        throw new IllegalArgumentException("shard must be non-negative (uint64), but was: " + shard);
-    }
-    this.shard = shard;
 }
 ```
 

--- a/guides/java-files/UnsignedValidator.java
+++ b/guides/java-files/UnsignedValidator.java
@@ -1,0 +1,117 @@
+package org.hiero.sdk.validation;
+
+/**
+ * Utility class for validating unsigned integer semantics in Java.
+ *
+ * <p>Java does not have native unsigned integer types. The Hiero SDK maps unsigned meta-language
+ * types ({@code uint8}, {@code uint16}, {@code uint64}) to signed Java primitives ({@code byte},
+ * {@code short}/{@code int}, {@code long}). This class enforces unsigned semantics by rejecting
+ * negative values and values that exceed the unsigned range.
+ *
+ * <p>All methods throw {@link IllegalArgumentException} if the value is outside the valid range.
+ * Values are never silently clamped or transformed.
+ *
+ * <p><strong>Ranges:</strong>
+ * <ul>
+ *   <li>{@code uint8}  — 0 to 255</li>
+ *   <li>{@code uint16} — 0 to 65535</li>
+ *   <li>{@code uint64} — 0 to {@link Long#MAX_VALUE} (negative {@code long} values are rejected)</li>
+ * </ul>
+ *
+ * <p><strong>Usage example:</strong>
+ * <pre>{@code
+ * public class ConsensusNode {
+ *
+ *     private final int port;
+ *
+ *     public ConsensusNode(final int port) {
+ *         this.port = UnsignedValidator.requireUint16(port, "port");
+ *     }
+ * }
+ * }</pre>
+ *
+ * @see <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-best-practices-java.md">
+ *     Java API Implementation Guideline — Unsigned Integer Semantics</a>
+ */
+public final class UnsignedValidator {
+
+    /**
+     * Maximum value for an unsigned 8-bit integer.
+     */
+    public static final int UINT8_MAX = 255;
+
+    /**
+     * Maximum value for an unsigned 16-bit integer.
+     */
+    public static final int UINT16_MAX = 65_535;
+
+    private UnsignedValidator() {
+        // Prevent instantiation
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+    /**
+     * Validates that the given value is within the unsigned 8-bit integer range (0 to 255).
+     *
+     * <p>This method should be used at input boundaries (constructors, setters, builder methods)
+     * for fields mapped from the meta-language type {@code uint8}.
+     *
+     * @param value the value to validate
+     * @param name  the name of the parameter, used in the exception message
+     * @return the validated value, for convenient inline use
+     * @throws IllegalArgumentException if the value is negative or greater than 255
+     */
+    public static int requireUint8(final int value, final String name) {
+        if (value < 0 || value > UINT8_MAX) {
+            throw new IllegalArgumentException(
+                    name + " must be in the range 0 to " + UINT8_MAX + " (uint8), but was: " + value
+            );
+        }
+        return value;
+    }
+
+    /**
+     * Validates that the given value is within the unsigned 16-bit integer range (0 to 65535).
+     *
+     * <p>This method should be used at input boundaries (constructors, setters, builder methods)
+     * for fields mapped from the meta-language type {@code uint16}.
+     *
+     * @param value the value to validate
+     * @param name  the name of the parameter, used in the exception message
+     * @return the validated value, for convenient inline use
+     * @throws IllegalArgumentException if the value is negative or greater than 65535
+     */
+    public static int requireUint16(final int value, final String name) {
+        if (value < 0 || value > UINT16_MAX) {
+            throw new IllegalArgumentException(
+                    name + " must be in the range 0 to " + UINT16_MAX + " (uint16), but was: " + value
+            );
+        }
+        return value;
+    }
+
+    /**
+     * Validates that the given value is non-negative, enforcing unsigned 64-bit integer semantics.
+     *
+     * <p>Java's {@code long} can represent values from {@link Long#MIN_VALUE} to
+     * {@link Long#MAX_VALUE}. Since {@code long} cannot represent the full {@code uint64} range
+     * (0 to 2^64 - 1), this method enforces the maximum representable unsigned range: 0 to
+     * {@link Long#MAX_VALUE}. Any negative value is rejected.
+     *
+     * <p>This method should be used at input boundaries (constructors, setters, builder methods)
+     * for fields mapped from the meta-language type {@code uint64}.
+     *
+     * @param value the value to validate
+     * @param name  the name of the parameter, used in the exception message
+     * @return the validated value, for convenient inline use
+     * @throws IllegalArgumentException if the value is negative
+     */
+    public static long requireUint64(final long value, final String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                    name + " must be non-negative (uint64), but was: " + value
+            );
+        }
+        return value;
+    }
+}

--- a/guides/java-files/UnsignedValidatorTest.java
+++ b/guides/java-files/UnsignedValidatorTest.java
@@ -1,0 +1,257 @@
+package org.hiero.sdk.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link UnsignedValidator} covering all unsigned integer type boundaries.
+ *
+ * <p>Each test follows the Given-When-Then pattern as defined in the
+ * <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-best-practices-java.md">
+ * Java API Implementation Guideline</a>.
+ */
+class UnsignedValidatorTest {
+
+
+
+    @Test
+    void testRequireUint8AcceptsZero() {
+
+        final int value = 0;
+
+  
+        final int result = UnsignedValidator.requireUint8(value, "testField");
+
+        assertEquals(0, result, "uint8 must accept 0");
+    }
+
+    @Test
+    void testRequireUint8AcceptsMaxBoundary() {
+        final int value = 255;
+
+        final int result = UnsignedValidator.requireUint8(value, "testField");
+
+        assertEquals(255, result, "uint8 must accept 255");
+    }
+
+    @Test
+    void testRequireUint8AcceptsMidRangeValue() {
+      
+        final int value = 128;
+
+        final int result = UnsignedValidator.requireUint8(value, "testField");
+
+        
+        assertEquals(128, result, "uint8 must accept values within range");
+    }
+
+
+    @Test
+    void testRequireUint8RejectsNegativeValue() {
+        final int value = -1;
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint8(value, "testField"),
+                "uint8 must reject negative values"
+        );
+        assertEquals(
+                "testField must be in the range 0 to 255 (uint8), but was: -1",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void testRequireUint8RejectsValueAboveMax() {
+       
+        final int value = 256;
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint8(value, "testField"),
+                "uint8 must reject values above 255"
+        );
+        assertEquals(
+                "testField must be in the range 0 to 255 (uint8), but was: 256",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void testRequireUint8RejectsLargeNegativeValue() {
+   
+        final int value = Integer.MIN_VALUE;
+
+        
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint8(value, "testField"),
+                "uint8 must reject Integer.MIN_VALUE"
+        );
+    }
+
+
+    @Test
+    void testRequireUint16AcceptsZero() {
+        final int value = 0;
+
+        final int result = UnsignedValidator.requireUint16(value, "port");
+
+        assertEquals(0, result, "uint16 must accept 0");
+    }
+
+    @Test
+    void testRequireUint16AcceptsMaxBoundary() {
+       
+        final int value = 65535;
+        final int result = UnsignedValidator.requireUint16(value, "port");
+
+        assertEquals(65535, result, "uint16 must accept 65535");
+    }
+
+    @Test
+    void testRequireUint16AcceptsTypicalPort() {
+       
+        final int value = 50211;
+
+      
+        final int result = UnsignedValidator.requireUint16(value, "port");
+
+       
+        assertEquals(50211, result, "uint16 must accept typical port values");
+    }
+
+   
+
+    @Test
+    void testRequireUint16RejectsNegativeValue() {
+       
+        final int value = -1;
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint16(value, "port"),
+                "uint16 must reject negative values"
+        );
+        assertEquals(
+                "port must be in the range 0 to 65535 (uint16), but was: -1",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void testRequireUint16RejectsValueAboveMax() {
+    
+        final int value = 65536;
+
+       
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint16(value, "port"),
+                "uint16 must reject values above 65535"
+        );
+        assertEquals(
+                "port must be in the range 0 to 65535 (uint16), but was: 65536",
+                exception.getMessage()
+        );
+    }
+
+   
+
+    @Test
+    void testRequireUint64AcceptsZero() {
+       
+        final long value = 0L;
+
+      
+        final long result = UnsignedValidator.requireUint64(value, "shard");
+
+       
+        assertEquals(0L, result, "uint64 must accept 0");
+    }
+
+    @Test
+    void testRequireUint64AcceptsMaxBoundary() {
+     
+        final long value = Long.MAX_VALUE;
+
+       
+        final long result = UnsignedValidator.requireUint64(value, "shard");
+
+      
+        assertEquals(Long.MAX_VALUE, result, "uint64 must accept Long.MAX_VALUE");
+    }
+
+    @Test
+    void testRequireUint64AcceptsTypicalValue() {
+      
+        final long value = 1_000_000L;
+
+      
+        final long result = UnsignedValidator.requireUint64(value, "realm");
+
+        
+        assertEquals(1_000_000L, result, "uint64 must accept typical positive values");
+    }
+
+
+    @Test
+    void testRequireUint64RejectsNegativeValue() {
+        final long value = -1L;
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint64(value, "shard"),
+                "uint64 must reject negative values"
+        );
+        assertEquals(
+                "shard must be non-negative (uint64), but was: -1",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void testRequireUint64RejectsMinLongValue() {
+        final long value = Long.MIN_VALUE;
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UnsignedValidator.requireUint64(value, "shard"),
+                "uint64 must reject Long.MIN_VALUE"
+        );
+    }
+
+
+    @Test
+    void testRequireUint8ReturnsValidatedValue() {
+        
+        final int value = 42;
+
+        final int result = UnsignedValidator.requireUint8(value, "field");
+
+        assertEquals(42, result, "requireUint8 must return the validated value for inline use");
+    }
+
+    @Test
+    void testRequireUint16ReturnsValidatedValue() {
+   
+        final int value = 8080;
+       
+        final int result = UnsignedValidator.requireUint16(value, "field");
+
+        assertEquals(8080, result, "requireUint16 must return the validated value for inline use");
+    }
+
+    @Test
+    void testRequireUint64ReturnsValidatedValue() {
+       
+        final long value = 999L;
+        
+        final long result = UnsignedValidator.requireUint64(value, "field");
+        
+        assertEquals(999L, result, "requireUint64 must return the validated value for inline use");
+    }
+}


### PR DESCRIPTION
Adds a utility for validating unsigned integer values (uint8, uint16, uint64) with strict boundary checks, along with usage examples and unit tests.

Fixes #160 