### PR TITLE
docs: relax Java namespace to module restriction

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -2683,8 +2683,9 @@ src/
 
 ## Namespace Mapping
 
-The meta-language uses namespaces to group related types and functionality. In Java, namespaces map to a combination of
-**packages** and **JPMS modules**.
+The meta-language uses namespaces to group related types and functionality. In Java, each namespace maps to a **Java
+package**. A Java module may contain one or more namespaces. It is not required to create a separate module for each
+namespace.
 
 ### Namespace Concept
 
@@ -2710,10 +2711,8 @@ enum TransactionStatus {
 
 ### Java Implementation of Namespaces
 
-Namespaces are implemented using:
-
-1. **Java Package** - for code organization (`org.hiero.transactions`)
-2. **JPMS Module** - for encapsulation and dependency management
+Each namespace is implemented as a **Java Package** for code organization (e.g., `org.hiero.transactions`). One or more
+namespace packages may reside within the same JPMS module for encapsulation and dependency management.
 
 **Package Structure**:
 


### PR DESCRIPTION
Update Java namespace guideline to remove the restriction that each namespace must be a separate module. Allow multiple namespaces within a single Java module to better align with standard Java practices.
1 . Relax namespace-to-module constraint
2 . Clarify that a Java module may contain one or more namespaces
3 . Keep existing mapping of namespaces to Java packages intact
Fixes #163