### PR TITLE
docs: add HIP-1137 response codes to SDK design doc

### DIFF
--- a/proposals/hips/hip-1137.md
+++ b/proposals/hips/hip-1137.md
@@ -227,7 +227,17 @@ All three registered node transactions (`RegisteredNodeCreateTransaction`, `Regi
 
 ### Response Codes
 
-HIP-1137 does not define any new response codes. If response codes specific to registered node transactions are introduced during consensus node implementation, this document should be updated to document them and evaluate any transaction retry implications for the SDKs.
+- `INVALID_REGISTERED_NODE_ID` — The registered node ID is invalid or does not exist in network state.
+- `INVALID_REGISTERED_ENDPOINT` — A service endpoint is invalid; the port is out of range, or no address field is set.
+- `REGISTERED_ENDPOINTS_EXCEEDED_LIMIT` — The service endpoint list exceeds the maximum of 50 entries.
+- `INVALID_REGISTERED_ENDPOINT_ADDRESS` — A service endpoint has an invalid address; the IP address is not 4 (IPv4) or 16 (IPv6) bytes, or the domain name is not a valid ASCII FQDN.
+- `INVALID_REGISTERED_ENDPOINT_TYPE` — A service endpoint does not specify an endpoint type.
+- `REGISTERED_NODE_STILL_ASSOCIATED` — The registered node cannot be deleted because it is still referenced in a consensus node's associated registered node list.
+- `MAX_REGISTERED_NODES_EXCEEDED` — The `associatedRegisteredNodes` list on a `NodeCreateTransaction` or `NodeUpdateTransaction` exceeds the maximum of 20 entries.
+
+#### Transaction Retry
+
+None of these response codes represent transient failures. SDKs should not retry on any of them.
 
 ## Test Plan
 

--- a/proposals/hips/hip-1137.md
+++ b/proposals/hips/hip-1137.md
@@ -253,9 +253,9 @@ None of these response codes represent transient failures. SDKs should not retry
 
 6. Given a valid admin key, a description, and service endpoints, when a `RegisteredNodeCreateTransaction` is executed, then the transaction succeeds and the registered node is created with the provided description.
 
-7. Given a `RegisteredNodeCreateTransaction` with no admin key set, when the transaction is executed, then the transaction fails.
+7. Given a `RegisteredNodeCreateTransaction` with no admin key set, when the transaction is executed, then the transaction fails with a precheck status of `KEY_REQUIRED`.
 
-8. Given a `RegisteredNodeCreateTransaction` with an empty service endpoints list, when the transaction is executed, then the transaction fails.
+8. Given a `RegisteredNodeCreateTransaction` with an empty service endpoints list, when the transaction is executed, then the transaction fails with a receipt status of `INVALID_REGISTERED_ENDPOINT`.
 
 9. Given an existing registered node, when a `RegisteredNodeUpdateTransaction` updates the description, then the description is replaced and the update succeeds.
 
@@ -263,15 +263,15 @@ None of these response codes represent transient failures. SDKs should not retry
 
 11. Given an existing registered node, when a `RegisteredNodeUpdateTransaction` sets a new admin key and the transaction is signed by both the old and new admin keys, then the admin key is updated successfully.
 
-12. Given an existing registered node, when a `RegisteredNodeUpdateTransaction` sets a new admin key but only the old admin key signs, then the transaction fails.
+12. Given an existing registered node, when a `RegisteredNodeUpdateTransaction` sets a new admin key but only the old admin key signs, then the transaction fails with a receipt status of `INVALID_SIGNATURE`.
 
-13. Given a `RegisteredNodeUpdateTransaction` targeting a non-existent `registeredNodeId`, when the transaction is executed, then the transaction fails.
+13. Given a `RegisteredNodeUpdateTransaction` targeting a non-existent `registeredNodeId`, when the transaction is executed, then the transaction fails with a receipt status of `INVALID_REGISTERED_NODE_ID`.
 
 14. Given an existing registered node, when a `RegisteredNodeDeleteTransaction` is executed and signed by the admin key, then the registered node is removed from the address book.
 
-15. Given a registered node that has already been deleted, when a `RegisteredNodeDeleteTransaction` is executed for the same `registeredNodeId`, then the transaction fails.
+15. Given a registered node that has already been deleted, when a `RegisteredNodeDeleteTransaction` is executed for the same `registeredNodeId`, then the transaction fails with a receipt status of `INVALID_REGISTERED_NODE_ID`.
 
-16. Given a `RegisteredNodeDeleteTransaction` targeting a non-existent `registeredNodeId`, when the transaction is executed, then the transaction fails.
+16. Given a `RegisteredNodeDeleteTransaction` targeting a non-existent `registeredNodeId`, when the transaction is executed, then the transaction fails with a receipt status of `INVALID_REGISTERED_NODE_ID`.
 
 17. Given an existing registered node, when a `NodeCreateTransaction` is executed with the registered node's ID in `associatedRegisteredNodes`, then the consensus node is created with the association.
 


### PR DESCRIPTION
## Summary

Updates the HIP-1137 SDK design doc to document the seven new response codes introduced by the consensus node implementation of registered node transactions. The previous text incorrectly stated that HIP-1137 defines no new response codes.

## Changes

### Response Codes

Replaced the placeholder note in the Internal Changes / Response Codes section with the full set of registered-node-specific response codes (529–535) and a transaction retry note.

| Code | Value | Description |
|------|-------|-------------|
| `INVALID_REGISTERED_NODE_ID` | 529 | Registered node ID is invalid or does not exist |
| `INVALID_REGISTERED_ENDPOINT` | 530 | Port is out of range or address field is not set |
| `REGISTERED_ENDPOINTS_EXCEEDED_LIMIT` | 531 | Service endpoint list exceeds the 50-entry limit |
| `INVALID_REGISTERED_ENDPOINT_ADDRESS` | 532 | IP address is not 4/16 bytes, or domain name is not a valid ASCII FQDN |
| `INVALID_REGISTERED_ENDPOINT_TYPE` | 533 | Endpoint does not specify an endpoint type |
| `REGISTERED_NODE_STILL_ASSOCIATED` | 534 | Node cannot be deleted; still referenced by a consensus node |
| `MAX_REGISTERED_NODES_EXCEEDED` | 535 | `associatedRegisteredNodes` list exceeds the 20-entry limit |

## Files Changed Summary

| File | Change |
|------|--------|
| `proposals/hips/hip-1137.md` | Response Codes section replaced with full code list and retry guidance |

## Breaking Changes

**None.** Documentation-only change.
