### PR TITLE
`docs: fix broken relative links in issue progression maintainer README`

### DIFF
--- a/guides/issue-progression/for-maintainers/README.md
+++ b/guides/issue-progression/for-maintainers/README.md
@@ -128,19 +128,19 @@ For example, a developer may be considered as a candidate for a maintainer once 
 ## Further Reading for Maintainers
 Follow these recommended steps:
 
-[1. Label Issues by Difficulty](guides/issue-progression/for-maintainers/labelling-issues-examples.md)
+[1. Label Issues by Difficulty](./labelling-issues-examples.md)
 
-[Creating Issues Examples](guides/issue-progression/for-maintainers/creating-issues-examples.md)
+[Creating Issues Examples](./creating-issues-examples.md)
 
-[AI Prompts to Create Issues](guides/issue-progression/for-maintainers/creating-issues-AI-prompts.md)
+[AI Prompts to Create Issues](./creating-issues-AI-prompts.md)
 
-[Reviewing Strategies At Each Difficulty](guides/issue-progression/for-maintainers/reviewing-pull-requests.md)
+[Reviewing Strategies At Each Difficulty](./reviewing-pull-requests.md)
 
 ## Resources
 
-[Issue Templates for Maintainers Tailored to Difficulty](guides/issue-progression/for-maintainers/editable-templates)
+[Issue Templates for Maintainers Tailored to Difficulty](./editable-templates)
 
-[Documents for Developers Tailored to Difficulty](guides/issue-progression/for-developers)
+[Documents for Developers Tailored to Difficulty](../for-developers)
 
 
 ---


### PR DESCRIPTION
## Description

Fixes 6 broken relative links in the "Further Reading for Maintainers" and "Resources" sections of `guides/issue-progression/for-maintainers/README.md`.

### Problem

The links used repo-root-relative paths like:
```
guides/issue-progression/for-maintainers/labelling-issues-examples.md
```

Since the file is already inside `guides/issue-progression/for-maintainers/`, these paths resolved to a **non-existent nested directory**:
```
guides/issue-progression/for-maintainers/guides/issue-progression/for-maintainers/...
```

### Fix

Replaced all 6 links with correct relative paths:

| Before (broken) | After (fixed) |
|:---|:---|
| `guides/issue-progression/for-maintainers/labelling-issues-examples.md` | `./labelling-issues-examples.md` |
| `guides/issue-progression/for-maintainers/creating-issues-examples.md` | `./creating-issues-examples.md` |
| `guides/issue-progression/for-maintainers/creating-issues-AI-prompts.md` | `./creating-issues-AI-prompts.md` |
| `guides/issue-progression/for-maintainers/reviewing-pull-requests.md` | `./reviewing-pull-requests.md` |
| `guides/issue-progression/for-maintainers/editable-templates` | `./editable-templates` |
| `guides/issue-progression/for-developers` | `../for-developers` |

## Files Changed Summary

| File | Change |
|------|--------|
| `guides/issue-progression/for-maintainers/README.md` | Fix 6 broken relative links |

## Breaking Changes

**None.** Documentation-only change.

## Checklist

- [x] Documented
- [x] No unrelated changes
- [x] All links verified to resolve correctly

Fixes #197

