### PR TITLE
docs: fix duplicate step numbering in contributor workflow guide

### DIFF
--- a/guides/issue-progression/for-developers/contributor-workflow.md
+++ b/guides/issue-progression/for-developers/contributor-workflow.md
@@ -207,7 +207,7 @@ Navigate the repository pull request section:
 
 You will see a banner showing your branch with a “Compare & pull request” button. Click it.
 
-3. Write a Good Title and Description
+4. Write a Good Title and Description
 Conventionally Name your *Pull Request* Title [Guide](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 
 For example:
@@ -215,7 +215,7 @@ For example:
 
 Add a brief description and any important notes.
 
-4. Link the Pull Request to an Issue
+5. Link the Pull Request to an Issue
 To link a pull request to an issue, add one of the following lines
 to the **pull request description**:
 
@@ -231,7 +231,7 @@ GitHub to automatically manage issue state.
 
 Double check the content, then click 'ready to review' and submit!
 
-4. Wait for Checks
+6. Wait for Checks
 We have several security and quality checks.
 
 Please review and check they all pass.
@@ -245,6 +245,6 @@ If checks are solving and you require help, you can:
 - Attend [Community Calls](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week)
 - Ask for help on the pull request
 
-5. Once approved
+7. Once approved
 Once your pull request passes checks and is approved, it will shortly be merged to main.
 Congratulations!


### PR DESCRIPTION

## Description

Fixes duplicate step numbers in the "Submitting a Pull Request" section (§5) of `guides/issue-progression/for-developers/contributor-workflow.md`.

### Problem

The section had two steps numbered "3." and two steps numbered "4.", making it confusing for contributors following the guide:

| Step Title | Before | After |
|:---|:---|:---|
| Open a Pull Request | 3. ✅ | 3. ✅ |
| Write a Good Title and Description | 3. ❌ | 4. ✅ |
| Link the Pull Request to an Issue | 4. ❌ | 5. ✅ |
| Wait for Checks | 4. ❌ | 6. ✅ |
| Once approved | 5. ❌ | 7. ✅ |

### Fix

Corrected all step numbers to sequential order: 1, 2, 3, 4, 5, 6, 7.

## Files Changed Summary

| File | Change |
|------|--------|
| `guides/issue-progression/for-developers/contributor-workflow.md` | Fix duplicate step numbering in §5 |

## Breaking Changes

**None.** Documentation-only change.

## Checklist

- [x] Documented
- [x] No unrelated changes
- [x] Step numbering verified to be sequential

Fixes #199