### PR TITLE
docs: clarify Python-specific setup in contributor guide (Step 6)

### DIFF
--- a/guides/issue-progression/for-developers/contributor-setup.md
+++ b/guides/issue-progression/for-developers/contributor-setup.md
@@ -134,6 +134,11 @@ git remote add upstream https://github.com/hiero-ledger/hiero-sdk-python.git
 ```
 
 ## 6. Install Packages and Protobufs
+
+> ⚠️ **NOTE**: The instructions below are specific to the **Python SDK** (`hiero-sdk-python`). If you are contributing to a different SDK (C++, Java, JavaScript, Go, Swift, Rust), please refer to that SDK's own `README.md` or `CONTRIBUTING.md` for setup instructions.
+
+### Python SDK Setup
+
 This installs the package manager uv:
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
## Description

Clarifies that Step 6 ("Install Packages and Protobufs") in:

guides/issue-progression/for-developers/contributor-setup.md

contains Python-specific instructions.

### Problem

The contributor setup guide is presented as a generic guide for all SDK contributors.

However, Step 6 includes instructions specific to the Python SDK:
- Installing `uv`
- Running `uv sync`
- Running `uv run python generate_proto.py`

This can confuse contributors working on other SDKs (e.g., JavaScript, Java, C++, Go, Swift, Rust), as these steps do not apply to them.

### Fix

- Added a clear note at the beginning of Step 6 indicating the instructions are Python SDK-specific
- Directed contributors working on other SDKs to refer to their respective SDK documentation (`README.md` or `CONTRIBUTING.md`)
- Preserved all existing Python-specific instructions without modification

### Changes

- Added clarification note to Step 6
- No changes to existing Python setup steps

## Files Changed

- guides/issue-progression/for-developers/contributor-setup.md

## Breaking Changes

None (documentation only)

Fixes #201