### PR TITLE
docs: apply simple type and wording consistency fixes

### DIFF
--- a/proposals/hips/hip-1195.md
+++ b/proposals/hips/hip-1195.md
@@ -45,7 +45,7 @@ HookCreationDetails {
     extensionPoint: HookExtensionPoint
 
     // The id to create the hook at
-    hookId: long
+    hookId: int64
 
     // The hook implementation - a hook programmed in EVM bytecode that may access state or interact with external contracts
     evmHook: EvmHook
@@ -108,7 +108,7 @@ EvmHookMappingEntry {
 
 HookCall {
     // The id of the hook to call
-    hookId: long
+    hookId: int64
 
     // Specification of how to call an EVM hook
     evmHookCall: EvmHookCall
@@ -142,7 +142,7 @@ EvmHookCall {
 // Specifies a hook identifier from within a transaction.
 HookId {
     entityId: HookEntityId
-    hookId: long
+    hookId: int64
 }
 
 // Specifies the entity that owns the hook (one of accountId or contractId must be provided)
@@ -208,16 +208,16 @@ AccountUpdateTransaction {
     AccountUpdateTransaction setHooksToCreate(hooks: list<HookCreationDetails>)
     
     // Mark a hook for deletion from the account
-    AccountUpdateTransaction addHookToDelete(hookId: long)
+    AccountUpdateTransaction addHookToDelete(hookId: int64)
     
     // Mark hooks for deletion from the account
-    AccountUpdateTransaction setHooksToDelete(hookIds: list<long>)
+    AccountUpdateTransaction setHooksToDelete(hookIds: list<int64>)
     
     // Get the list of hooks to be created
     list<HookCreationDetails> getHooksToCreate()
     
     // Get the list of hook IDs to be deleted
-    list<long> getHooksToDelete()
+    list<int64> getHooksToDelete()
 }
 ```
 
@@ -245,16 +245,16 @@ ContractUpdateTransaction {
     ContractUpdateTransaction setHooksToCreate(hooks: list<HookCreationDetails>)
     
     // Mark a hook for deletion from the contract
-    ContractUpdateTransaction addHookToDelete(hookId: long)
+    ContractUpdateTransaction addHookToDelete(hookId: int64)
     
     // Mark hooks for deletion from the contract
-    ContractUpdateTransaction setHooksToDelete(hookIds: list<long>)
+    ContractUpdateTransaction setHooksToDelete(hookIds: list<int64>)
     
     // Get the list of hooks to be created
     list<HookCreationDetails> getHooksToCreate()
     
     // Get the list of hook IDs to be deleted
-    list<long> getHooksToDelete()
+    list<int64> getHooksToDelete()
 }
 ```
 
@@ -268,7 +268,7 @@ TransferTransaction {
     TransferTransaction addNftTransferWithHook(nftId: NftId, senderAccountId: AccountId, receiverAccountId: AccountId, senderHookCall: NftHookCall, receiverHookCall: NftHookCall)
     
     // Add token transfer with hook (PRE_HOOK or PRE_POST_HOOK)
-    TransferTransaction addTokenTransferWithHook(tokenId: TokenId, accountId: AccountId, amount: long, hookCall: FungibleHookCall)
+    TransferTransaction addTokenTransferWithHook(tokenId: TokenId, accountId: AccountId, amount: int64, hookCall: FungibleHookCall)
 }
 ```
 

--- a/proposals/hips/hip-1313.md
+++ b/proposals/hips/hip-1313.md
@@ -13,10 +13,10 @@ Transaction {
     // Set whether to use high-volume throttles for this transaction.
     // When true, enables high-volume throttles and pricing for entity creation.
     // Only affects supported transaction types; otherwise, it is ignored.
-    Transaction setHighVolume(highVolume: boolean)
+    Transaction setHighVolume(highVolume: bool)
     
     // Get whether high-volume throttles are enabled for this transaction.
-    boolean getHighVolume()
+    bool getHighVolume()
 }
 ```
 

--- a/v3-sandbox/prototype-api/keys.md
+++ b/v3-sandbox/prototype-api/keys.md
@@ -172,7 +172,7 @@ Here you can find the complete list of rules as a basic implementation of the en
 
 ### Key examples
 
-The following examples show the different key formats as String representations.
+The following examples show the different key formats as string representations.
 
 #### PKCS#8 + DER (Private Key)
 

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -58,7 +58,7 @@ abstraction TransactionSigner {
 //                for transactions that do not add entity-specific receipt fields.
 abstraction TransactionBuilder<$$Builder extends TransactionBuilder, $$Response extends Response> {
   @@nullable maxTransactionFee: common.Hbar
-  @@nullable validDuration: long
+  @@nullable validDuration: int64
   @@nullable memo: string
   @@nullable transactionId: TransactionId
   nodeAccountIds: list<common.AccountId>
@@ -84,9 +84,9 @@ abstraction TransactionBuilder<$$Builder extends TransactionBuilder, $$Response 
 Transaction<$$Response extends Response> {
   // Network execution config — does not affect the signed transaction body
   @@nullable maxAttempts: int32
-  @@nullable maxBackoff: long
-  @@nullable minBackoff: long
-  @@nullable attemptTimeout: long
+  @@nullable maxBackoff: int64
+  @@nullable minBackoff: int64
+  @@nullable attemptTimeout: int64
 
   // Sign the transaction with the given key pair. Returns self to allow chaining.
   Transaction<$$Response> sign(keyPair: keys.KeyPair)


### PR DESCRIPTION
## Summary

This PR applies a small batch of low-risk documentation/spec consistency fixes.

## Changes

- Replaced undefined `long` with canonical `int64` in DSL API signatures.
- Replaced `list<long>` with `list<int64>` in HIP API sections.
- Normalized `boolean` to `bool` in HIP DSL snippets.
- Minor wording/casing cleanup in keys doc (`String` -> `string` in prose).

## Files

- v3-sandbox/prototype-api/transactions.md
- v3-sandbox/prototype-api/keys.md
- proposals/hips/hip-1195.md
- proposals/hips/hip-1313.md

## Why

These are simple consistency fixes aligned with `guides/api-guideline.md` canonical types and naming conventions, with minimal semantic risk.