### PR TITLE
docs: update support team tag in issue templates

### DIFF
--- a/guides/issue-progression/for-maintainers/editable-templates/00-good-first-issue-candidate.yml
+++ b/guides/issue-progression/for-maintainers/editable-templates/00-good-first-issue-candidate.yml
@@ -241,7 +241,7 @@ body:
 
         > [!TIP]
         >
-        > - Comment on this issue and ask maintainers or tag `@good_first_issue_support_team`
+        > - Comment on this issue and ask maintainers or tag `@hiero-ledger/hiero-sdk-good-first-issue-support`
         >
         
         #### Other Resources:

--- a/guides/issue-progression/for-maintainers/editable-templates/01-good-first-issue.yml
+++ b/guides/issue-progression/for-maintainers/editable-templates/01-good-first-issue.yml
@@ -228,7 +228,7 @@ body:
 
         > [!TIP]
         >
-        > - Comment on this issue and ask maintainers or tag `@good_first_issue_support_team`
+        > - Comment on this issue and ask maintainers or tag `@hiero-ledger/hiero-sdk-good-first-issue-support`
         >
         
         #### Other Resources:


### PR DESCRIPTION
**Description**:
updated the maintainer instructions in two issue template files to reference the correct GitHub team for good first issue support.

**Related issue(s)**:

Fixes #186

**Checklist**

- [x] Documented (Code comments, README, etc.)