### PR TITLE
docs: define `Subscribable` execution contract and streaming completion semantics

### DIFF
--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -311,6 +311,29 @@ The following annotations should be used:
   and futures are two distinct async patterns — a callback is invoked when work completes, while a future represents
   a pending result. Combining them (e.g., a callback that returns a future) should be avoided as it creates ambiguity
   about responsibility and completion semantics.
+- `@@streaming`: Indicates that the method initiates an asynchronous stream - a sequence of zero or more items
+  delivered over time, as opposed to a single deferred result. Every `@@streaming` method carries four mandatory
+  semantic guarantees that every language implementation must fulfill, regardless of the mechanism used:
+  1. **Item delivery** - zero or more items of the declared type are delivered to the consumer as they arrive.
+  2. **Error propagation** - transport failures, timeouts, and protocol errors are communicated to the consumer.
+     Errors may be terminal (the stream cannot continue) or, where applicable, handled internally via reconnect
+     logic before surfacing to the consumer.
+  3. **Completion signaling** - the consumer is notified when the stream has ended naturally. Completion is
+     server-driven: when an end condition (such as `endTime` or `endBlockNumber`) is set on the request, the
+     server enforces it and closes the stream; the SDK propagates that closure to the consumer. The SDK does
+     not monitor item values to detect end conditions client-side.
+  4. **Cancellation** - the consumer can terminate the stream early and release associated resources.
+
+  Like `@@async`, `@@streaming` does not prescribe a mechanism - it declares a semantic category. The concrete
+  method signature (return type, parameters, and how the four guarantees are fulfilled) is language-specific and
+  defined in each language's best practice guide.
+
+  Note: `@@streaming` and `@@async` are mutually exclusive on a method. `@@async` represents a single deferred
+  result; `@@streaming` represents a sequence of results delivered over time.
+  Note: `@@throws` does not apply to `@@streaming` methods. Errors are not thrown from `subscribe()` itself —
+  they are delivered through the language-specific error mechanism (e.g., an error callback, a thrown exception
+  inside the iteration loop, or an `Err` item in the stream). See the error propagation guarantee above and
+  each language's best practice guide for the concrete form.
 - `@@static`: Indicates that the method belongs to the type itself and can be called without an instance.
   Typical use cases are factory methods and deserialization methods.
   For example, `@@static Transaction fromBytes(payload: bytes)`.

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -330,10 +330,11 @@ The following annotations should be used:
 
   Note: `@@streaming` and `@@async` are mutually exclusive on a method. `@@async` represents a single deferred
   result; `@@streaming` represents a sequence of results delivered over time.
-  Note: `@@throws` does not apply to `@@streaming` methods. Errors are not thrown from `subscribe()` itself —
-  they are delivered through the language-specific error mechanism (e.g., an error callback, a thrown exception
-  inside the iteration loop, or an `Err` item in the stream). See the error propagation guarantee above and
-  each language's best practice guide for the concrete form.
+  Note: `@@throws` applies to `@@streaming` methods, but only for pre-stream failures — errors that occur
+  before the stream is established (e.g., invalid client state, failure to connect to any node after exhausting
+  all retry attempts). Once the stream is open and delivering items, errors are communicated through the
+  language-specific stream mechanism (e.g., an error callback, a thrown exception inside the iteration loop,
+  or an `Err` item in the stream) rather than thrown from `subscribe()` itself.
 - `@@static`: Indicates that the method belongs to the type itself and can be called without an instance.
   Typical use cases are factory methods and deserialization methods.
   For example, `@@static Transaction fromBytes(payload: bytes)`.

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -312,30 +312,12 @@ The following annotations should be used:
   and futures are two distinct async patterns — a callback is invoked when work completes, while a future represents
   a pending result. Combining them (e.g., a callback that returns a future) should be avoided as it creates ambiguity
   about responsibility and completion semantics.
-- `@@streaming`: Indicates that the method initiates an asynchronous stream - a sequence of zero or more items
-  delivered over time, as opposed to a single deferred result. Every `@@streaming` method carries four mandatory
-  semantic guarantees that every language implementation must fulfill, regardless of the mechanism used:
-  1. **Item delivery** - zero or more items of the declared type are delivered to the consumer as they arrive.
-  2. **Error propagation** - transport failures, timeouts, and protocol errors are communicated to the consumer.
-     Errors may be terminal (the stream cannot continue) or, where applicable, handled internally via reconnect
-     logic before surfacing to the consumer.
-  3. **Completion signaling** - the consumer is notified when the stream has ended naturally. Completion is
-     server-driven: when an end condition (such as `endTime` or `endBlockNumber`) is set on the request, the
-     server enforces it and closes the stream; the SDK propagates that closure to the consumer. The SDK does
-     not monitor item values to detect end conditions client-side.
-  4. **Cancellation** - the consumer can terminate the stream early and release associated resources.
-
-  Like `@@async`, `@@streaming` does not prescribe a mechanism - it declares a semantic category. The concrete
-  method signature (return type, parameters, and how the four guarantees are fulfilled) is language-specific and
-  defined in each language's best practice guide.
-
-  Note: `@@streaming` and `@@async` are mutually exclusive on a method. `@@async` represents a single deferred
-  result; `@@streaming` represents a sequence of results delivered over time.
-  Note: `@@throws` applies to `@@streaming` methods, but only for pre-stream failures — errors that occur
-  before the stream is established (e.g., invalid client state, failure to connect to any node after exhausting
-  all retry attempts). Once the stream is open and delivering items, errors are communicated through the
-  language-specific stream mechanism (e.g., an error callback, a thrown exception inside the iteration loop,
-  or an `Err` item in the stream) rather than thrown from `subscribe()` itself.
+- `@@streaming`: Indicates that the method returns an asynchronous stream of items — a pull-based sequence the
+  consumer drives at its own pace. The return type specifies the element type; use `streamResult<TYPE>` when
+  per-item errors are possible (non-terminal), or a plain type when all errors are terminal. `@@throws` declares
+  terminal stream-level errors (connection failure, authorization revoked, etc.). See [Streaming](#streaming) for
+  full semantics, per-item error handling, retry, cancellation, and language mappings.
+  Note: `@@streaming` and `@@async` are mutually exclusive — streaming already implies asynchronous item production.
 - `@@static`: Indicates that the method belongs to the type itself and can be called without an instance.
   Typical use cases are factory methods and deserialization methods.
   For example, `@@static Transaction fromBytes(payload: bytes)`.
@@ -552,6 +534,15 @@ streamResult<TopicMessage> subscribe(topicId: string, @@nullable retryPolicy: Re
 ```
 
 If the SDK exhausts its retry budget, the failure surfaces as a terminal stream-level error.
+
+#### Completion
+
+A stream completes when the server closes the connection. Completion is **server-driven**: when an end condition
+is set on the request (such as `endTime` or `endBlockNumber`), the server enforces it and closes the stream; the
+SDK propagates that closure to the consumer. The SDK does not monitor item values client-side to detect end
+conditions.
+
+When no end condition is set, the stream runs indefinitely until the consumer cancels it or a terminal error occurs.
 
 #### Cancellation
 

--- a/v3-sandbox/prototype-api/requests-core.md
+++ b/v3-sandbox/prototype-api/requests-core.md
@@ -28,6 +28,7 @@ interface Executable<$$Response> {
 // Does NOT extend Request - avoids diamond inheritance.
 interface Subscribable<$$Item> {
     @@streaming
+    @@throws(network-error, request-timeout, max-attempts-exceeded)
     subscribe(client: HieroClient)
 }
 ```

--- a/v3-sandbox/prototype-api/requests-core.md
+++ b/v3-sandbox/prototype-api/requests-core.md
@@ -1,0 +1,49 @@
+# Requests Core Types
+
+This document defines the execution contracts for the request hierarchy: `Executable` for unary requests that
+produce a single response, and `Subscribable` for streaming requests that produce an ongoing sequence of items.
+
+For the overall request hierarchy and how these contracts compose with network and transport axes, see
+[requests.md](requests.md) (defined in [PR #145](https://github.com/hiero-ledger/sdk-collaboration-hub/pull/145)).
+
+## API Schema
+
+```
+namespace requests-core
+requires common, client
+
+// ============================================================================
+// EXECUTION INTERFACES
+// ============================================================================
+
+// Any request that produces a single response via execute().
+// Does NOT extend Request - avoids diamond inheritance.
+interface Executable<$$Response> {
+    @@async
+    @@throws(network-error, request-timeout, max-attempts-exceeded)
+    $$Response execute(client: HieroClient)
+}
+
+// Any request that produces an ongoing stream of $$Item values via subscribe().
+// Does NOT extend Request - avoids diamond inheritance.
+interface Subscribable<$$Item> {
+    @@streaming
+    subscribe(client: HieroClient)
+}
+```
+
+## Comparison: Executable vs Subscribable
+
+| | `Executable<$$Response>` | `Subscribable<$$Item>` |
+|---|---|---|
+| Result cardinality | Exactly one response | Zero or more items over time |
+| Execution annotation | `@@async` | `@@streaming` |
+| Error mechanism | `@@throws` (propagates from `execute`) | Language-specific (thrown, `Err` item, callback) |
+| Completion | Implicit — `execute()` returns | Explicit — stream signals end |
+| Cancellation | Not applicable (single shot) | Required — see language guide |
+| Concurrency model | Future / promise / coroutine | Async iteration / reactive stream / callbacks |
+
+## Questions & Comments
+
+- Should `Subscribable` carry any retry/reconnect annotations, or is reconnect-on-disconnect purely an
+  internal SPI concern (i.e., transparent to the consumer unless all reconnect attempts fail)?

--- a/v3-sandbox/prototype-api/requests-core.md
+++ b/v3-sandbox/prototype-api/requests-core.md
@@ -26,10 +26,13 @@ interface Executable<$$Response> {
 
 // Any request that produces an ongoing stream of $$Item values via subscribe().
 // Does NOT extend Request - avoids diamond inheritance.
+// streamResult<$$Item> wraps each item as either a success value or a per-item error,
+// allowing the stream to continue past individual item failures (e.g. deserialization errors).
+// Terminal failures (connection lost, auth revoked) surface via @@throws.
 interface Subscribable<$$Item> {
     @@streaming
     @@throws(network-error, request-timeout, max-attempts-exceeded)
-    subscribe(client: HieroClient)
+    streamResult<$$Item> subscribe(client: HieroClient)
 }
 ```
 
@@ -38,10 +41,12 @@ interface Subscribable<$$Item> {
 | | `Executable<$$Response>` | `Subscribable<$$Item>` |
 |---|---|---|
 | Result cardinality | Exactly one response | Zero or more items over time |
+| Return type | `$$Response` | `streamResult<$$Item>` |
 | Execution annotation | `@@async` | `@@streaming` |
-| Error mechanism | `@@throws` (propagates from `execute`) | Language-specific (thrown, `Err` item, callback) |
-| Completion | Implicit — `execute()` returns | Explicit — stream signals end |
-| Cancellation | Not applicable (single shot) | Required — see language guide |
+| Per-item errors | Not applicable | Non-terminal — error variant of `streamResult<$$Item>` |
+| Terminal errors | `@@throws` | `@@throws` — stream ends, error surfaces via language mechanism |
+| Completion | Implicit — `execute()` returns | Server-driven — server closes stream when end condition reached |
+| Cancellation | Not applicable (single shot) | Implicit — stop iterating; SDK releases resources |
 | Concurrency model | Future / promise / coroutine | Async iteration / reactive stream / callbacks |
 
 ## Questions & Comments


### PR DESCRIPTION
## Summary

This PR defines the `Subscribable<$$Item>` execution interface in a new focused doc (`v3-sandbox/prototype-api/requests-core.md`) and makes two additions to `guides/api-guideline.md`: a concise `@@streaming` method annotation entry that points to the existing Streaming section, and a new `#### Completion` subsection documenting the server-driven completion model backed by research into the v2 SDK implementations and the mirror node source.

This work was spun out of [PR #145](https://github.com/hiero-ledger/sdk-collaboration-hub/pull/145) (new request hierarchy), where the `Subscribable` interface design drew extended review discussion. Separating it allows the design rationale to be captured and reviewed independently before the full hierarchy lands.

**Key changes:**
- `@@streaming` annotation entry added to the Method Annotations section of `api-guideline.md`, pointing to the `### Streaming` section (added by PR #221) for full details
- `#### Completion` subsection added to `### Streaming` documenting server-driven stream completion
- `v3-sandbox/prototype-api/requests-core.md` created, defining `Executable<$$Response>` and `Subscribable<$$Item>` side by side with a comparison table

---

## Motivation

### Why `Subscribable` needed its own PR

In PR #145, the `Subscribable` interface went through several design iterations in review. The initial definition was a near-empty semantic placeholder — `subscribe(client: HieroClient)` with no return type and no `@@throws`, and four behavioral requirements expressed only in prose comments. The review discussion centered on two questions: what should the consumer mechanism look like, and how should errors be handled. Pulling this work out allows those decisions to be made deliberately and documented clearly, separate from the rest of the request hierarchy.

### Why `@@streaming` rather than a `Subscriber<T>` type

The review suggested a `Subscriber`-based approach modeled on Java's `Flow.Subscriber`. This was considered and rejected because the idiomatic streaming models differ too fundamentally across the eight SDK languages to express as a single meta-language type:

- **Java and C++** are push-based: the SDK calls your callbacks. Java uses `Consumer<T>` callbacks returning a `SubscriptionHandle`; C++ uses lambdas with a RAII handle whose destructor cancels.
- **Swift and Rust** are pull-based: you iterate. Swift returns `AsyncThrowingStream<T, Error>` consumed with `for try await`; Rust returns `impl Stream<Item = Result<T, E>>` polled with `.next().await`.
- **TypeScript, Python, Go** are also pull-based: `AsyncIterable<T>` / `for await...of`, `AsyncGenerator[T]` / `async for`, channels with `context.Context`.

A `Subscriber<T>` type in the meta-language would apply naturally to Java, but a Swift developer reading it would have no idea where it fits — Swift doesn't use a subscriber object at all. Forcing any one model onto all languages would either be meaningless or would push some languages into unnatural patterns.

`@@streaming` follows the same approach as `@@async`: it declares the semantic category and the behavioral guarantees the implementation must fulfill, and defers the concrete mechanism to each language's best practice guide. This is consistent with how the meta-language handles other language-divergent concepts.

### The `streamResult<$$Item>` return type

PR #221 introduced `streamResult<TYPE>` and the two-level error model (per-item errors vs terminal stream-level errors). `Subscribable.subscribe()` uses `streamResult<$$Item>` as its return type because network subscriptions can produce per-item failures (deserialization errors, malformed messages) that should not terminate the stream. Terminal failures — connection lost after retries exhausted, authorization revoked — surface via `@@throws`, consistent with how `Executable.execute()` declares its terminal errors.

### Server-driven completion (research finding)

It was an open question whether the SDK or the server is responsible for enforcing end conditions like `endTime` and `endBlockNumber`. Examining the v2 SDK implementations and the mirror node source resolved this:

**v2 SDKs (Java, JavaScript, Go):** All three pass `endTime` to the server via protobuf (`consensusEndTime`) and perform no client-side timestamp checking. The completion signal fires when the server closes the gRPC stream.

**Mirror node (`TopicMessageServiceImpl.java`):** The server enforces end conditions using two mechanisms: `flux.takeWhile(t -> t.getConsensusTimestamp() < filter.getEndTime())` completes the reactive stream when a message at or past `endTime` arrives, and a polling signal (`pastEndTime`) terminates the stream once the current wall clock time passes `endTime` plus a configurable interval (~30 seconds), handling the case where no new messages arrive near the boundary.

The SDK's responsibility is to pass the condition in the request and propagate the resulting `onCompleted` gRPC signal. This is documented as the `#### Completion` subsection in `### Streaming`.

---

## Changes

### 1. `@@streaming` annotation entry (`guides/api-guideline.md`)

Added a concise `@@streaming` entry to the Method Annotations section immediately after `@@async`. It summarizes the annotation's purpose, notes the `streamResult<TYPE>` / plain-type distinction for per-item vs terminal errors, states that `@@throws` declares terminal stream-level errors, and points to the `### Streaming` section for full semantics.

This entry is intentionally short — matching the style of other annotation entries (`@@async`, `@@static`, `@@throws`) — because the `### Streaming` section (added by PR #221) is the canonical reference.

### 2. `#### Completion` subsection (`guides/api-guideline.md`)

Added a `#### Completion` subsection to the `### Streaming` section, between `#### Retry strategy` and `#### Cancellation`. The prior Streaming section had no completion coverage. The subsection documents:

- Completion is server-driven: the server closes the gRPC stream when the end condition is reached
- The SDK propagates that closure; it does not monitor item values client-side
- When no end condition is set, the stream runs indefinitely until the consumer cancels or a terminal error occurs

### 3. `Subscribable<$$Item>` interface (`v3-sandbox/prototype-api/requests-core.md`)

New file defining both execution interfaces side by side:

```
interface Executable<$$Response> {
    @@async
    @@throws(network-error, request-timeout, max-attempts-exceeded)
    $$Response execute(client: HieroClient)
}

interface Subscribable<$$Item> {
    @@streaming
    @@throws(network-error, request-timeout, max-attempts-exceeded)
    streamResult<$$Item> subscribe(client: HieroClient)
}
```

Both interfaces intentionally do not extend `Request` to avoid diamond inheritance — concrete request types already inherit from a network-specific base (`ConsensusRequest`, `MirrorRequest`, `BlockNodeRequest`) and implement one of these execution interfaces.

The file also includes a comparison table covering result cardinality, return type, execution annotation, per-item errors, terminal errors, completion model, cancellation model, and concurrency model side by side; and one open question retained for discussion.

---

## Open Questions

- Should `Subscribable` carry any retry/reconnect annotations, or is reconnect-on-disconnect purely an internal SPI concern (transparent to the consumer unless all reconnect attempts fail)?

---

## Files Changed Summary

| File | Change | Notes |
|---|---|---|
| `guides/api-guideline.md` | Modified | `@@streaming` annotation entry + `#### Completion` subsection |
| `v3-sandbox/prototype-api/requests-core.md` | Added | `Executable` + `Subscribable` interfaces, comparison table |

---

## Breaking Changes

**None.** Both changes are additive. The `@@streaming` annotation entry references the existing `### Streaming` section. The new `requests-core.md` is a net-new file with no dependents yet — PR #145 will adopt it when the full request hierarchy lands.

---

## Follow-up Items

- Each language best practice guide (`api-best-practices-{lang}.md`) needs a section documenting the concrete `subscribe()` signature: return type, parameter list (push overload for Java and C++), and how `streamResult<T>` maps to the language's native result type. PR #221 added the Java guide. The remaining seven need equivalent coverage.
- PR #145 should be updated to reference `requests-core.md` and adopt `streamResult<$$Item>` on `Subscribable`.
