### PR TITLE
feat: introduce asynchronous streaming

### DIFF
--- a/guides/api-best-practices-java.md
+++ b/guides/api-best-practices-java.md
@@ -34,50 +34,24 @@ Defensive implementation does **not** mean:
 
 Use the following canonical mappings when turning meta types into Java:
 
-| Generic Type                                                                     | Java Type                                                                                 | Notes |
-|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-------|
-| `string`                                                                         |
- `java.lang.String`                                                               | -                                                                                         |
-| `intX`                                                                           | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, 
- `java.lang.Long`, `java.math.BigInteger`                                         | For all definitions that are not `@@nullable` the primitive types should be               
- used                                                                             |
-| `uintX`                                                                          | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, 
- `java.lang.Long`, `java.math.BigInteger`                                         | For all definitions that are not `@@nullable` the primitive types should be               
- used                                                                             |
-| `double`                                                                         | `double`/                                                                                 
- `java.lang.Double`                                                               |
- For all definitions that are not `@@nullable` the primitive types should be used |
-| `decimal`                                                                        |
- `java.math.BigDecimal`                                                           | -                                                                                         |
-| `bool`                                                                           | `boolean`/                                                                                
- `java.lang.Boolean`                                                              |
- For all definitions that are not `@@nullable` the primitive types should be used |
-| `bytes`                                                                          | `byte[]`/                                                                                 
- `java.lang.Byte[]`                                                               |
- For all definitions that are not `@@nullable` the primitive types should be used |
-| `list<TYPE>`                                                                     |
- `java.util.List<TYPE>`                                                           |
- lists in the public API should always be immutable                               |
-| `set<TYPE>`                                                                      |
- `java.util.Set<TYPE>`                                                            |
- sets in the public API should always be immutable                                |
-| `map<KEY, VALUE>`                                                                |
- `java.util.Map<KEY, VALUE>`                                                      |
- maps in the public API should always be immutable                                |
-| `date`                                                                           |
- `java.time.LocalDate`                                                            | -                                                                                         |
-| `time`                                                                           |
- `java.time.LocalTime`                                                            | -                                                                                         |
-| `dateTime`                                                                       |
- `java.time.LocalDateTime`                                                        | -                                                                                         |
-| `zonedDateTime`                                                                  |
- `java.time.ZonedDateTime`                                                        | -                                                                                         |
-| `type`                                                                           |
- `java.lang.Class<?>`                                                             |
- Used for runtime type information, typically with generics `Class<T>`            |
-| `function<...>`                                                                  | `@FunctionalInterface` or                                                                 
- `java.util.function.*`                                                           |
- See [Function Types](#function-types) section below                              |
+| Generic Type      | Java Type                                                                                                                          | Notes                                                                            |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `string`          | `java.lang.String`                                                                                                                 | -                                                                                |
+| `intX`            | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long`, `java.math.BigInteger` | For all definitions that are not `@@nullable` the primitive types should be used |
+| `uintX`           | `byte`, `short`, `int`, `long`, `java.lang.Byte`, `java.lang.Short`, `java.lang.Integer`, `java.lang.Long`, `java.math.BigInteger` | For all definitions that are not `@@nullable` the primitive types should be used |
+| `double`          | `double`/ `java.lang.Double`                                                                                                       | For all definitions that are not `@@nullable` the primitive types should be used |
+| `decimal`         | `java.math.BigDecimal`                                                                                                             | -                                                                                |
+| `bool`            | `boolean`/`java.lang.Boolean`                                                                                                      | For all definitions that are not `@@nullable` the primitive types should be used |
+| `bytes`           | `byte[]`/`java.lang.Byte[]`                                                                                                        | For all definitions that are not `@@nullable` the primitive types should be used |
+| `list<TYPE>`      | `java.util.List<TYPE>`                                                                                                             | lists in the public API should always be immutable                               |
+| `set<TYPE>`       | `java.util.Set<TYPE>`                                                                                                              | sets in the public API should always be immutable                                |
+| `map<KEY, VALUE>` | `java.util.Map<KEY, VALUE>`                                                                                                        | maps in the public API should always be immutable                                |
+| `date`            | `java.time.LocalDate`                                                                                                              | -                                                                                |
+| `time`            | `java.time.LocalTime`                                                                                                              | -                                                                                |
+| `dateTime`        | `java.time.LocalDateTime`                                                                                                          | -                                                                                |
+| `zonedDateTime`   | `java.time.ZonedDateTime`                                                                                                          | -                                                                                |
+| `type`            | `java.lang.Class<?>`                                                                                                               | Used for runtime type information, typically with generics `Class<T>`            |
+| `function<...>`   | `@FunctionalInterface` or `java.util.function.*`                                                                                   | See [Function Types](#function-types) section below                              |
 
 ### Type Parameter for Runtime Type Information
 
@@ -1253,6 +1227,7 @@ Configuration {
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.hiero.sdk.annotation.ThreadSafe;
 
 public final class Configuration {
@@ -1347,6 +1322,7 @@ DataService {
 // Java implementation
 
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.hiero.sdk.annotation.ThreadSafe;
 
 public final class DataService {
@@ -1389,6 +1365,7 @@ DataCache {
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.hiero.sdk.annotation.ThreadSafe;
 
 public final class DataCache {
@@ -2850,6 +2827,314 @@ package org.hiero.accounts;
 
 **Note**: This creates a dependency, so `org.hiero.transactions` types appear in the public API. Consider whether
 `requires transitive` is needed (see [JPMS section](#java-platform-module-system-jpms)).
+
+## Streaming
+
+The meta-language `@@streaming` annotation declares methods that return an asynchronous stream of items. In Java, the
+SDK must provide two consumption modes:
+
+1. **Pull-based** (primary) — The canonical implementation. Returns a `HieroStream<T>` that the consumer iterates over
+   using a standard `for` loop or `Iterator`. All retry, reconnect, and domain logic lives here.
+2. **Push-based** (convenience adapter) — Built on top of the pull implementation using `java.util.concurrent.Flow`. The
+   push adapter contains zero domain logic and is derived automatically from the pull stream.
+
+### The `HieroStream<T>` interface (pull-based)
+
+The primary pull-based API is a custom `HieroStream<T>` interface that extends `Iterable<T>` and `AutoCloseable`. This
+allows consumers to use try-with-resources for automatic cleanup and enhanced `for` loops for iteration.
+See [java-files/HieroStream.java](java-files/HieroStream.java) for the full source with Javadoc.
+
+```java
+public interface HieroStream<T> extends Iterable<T>, AutoCloseable {
+
+    @Override
+    @NonNull
+    Iterator<T> iterator();
+
+    @Override
+    void close();
+}
+```
+
+Consumer usage:
+
+```
+try(HieroStream<StreamItem<TopicMessage>> stream = topicSubscription.subscribe(client)) {
+        for(StreamItem<TopicMessage> item :stream) {
+            switch(item) {
+                case StreamItem.Success<TopicMessage> s -> process(s.value());
+                case StreamItem.Error<TopicMessage> e ->log.warn("Bad message",e.error());
+            }
+        }
+} // AutoCloseable cancels the stream and releases resources
+```
+
+The `Iterator` returned by `HieroStream` blocks on `next()` until the next item is available. On Java 21+, this is
+efficient when consumed on a virtual thread — the virtual thread parks without blocking an OS thread. On older Java
+versions, the blocking is real but acceptable for most use cases since the consumer typically dedicates a thread to
+stream processing.
+
+### The `StreamItem<T>` sealed interface (per-item Result type)
+
+The meta-language `streamResult<TYPE>` maps to a sealed interface in Java. This type represents a single item in the
+stream that is either a success value or an error. It allows per-item error handling without terminating the stream.
+See [java-files/StreamItem.java](java-files/StreamItem.java) for the full source with Javadoc.
+
+```java
+public sealed interface StreamItem<T> permits StreamItem.Success, StreamItem.Error {
+
+    record Success<T>(@NonNull T value) implements StreamItem<T> {
+
+        public Success {
+            Objects.requireNonNull(value, "value must not be null");
+        }
+    }
+
+    record Error<T>(@NonNull Throwable error) implements StreamItem<T> {
+
+        public Error {
+            Objects.requireNonNull(error, "error must not be null");
+        }
+    }
+}
+```
+
+Consumer code uses pattern matching (Java 17+) to handle each variant:
+
+```
+for(StreamItem<TopicMessage> item : stream) {
+    switch(item){
+        case StreamItem.Success<TopicMessage> s -> process(s.value());
+        case StreamItem.Error<TopicMessage> e ->  log.warn("Item error: {}",e.error().getMessage());
+    }
+}
+```
+
+When a streaming method in the meta-language uses a plain return type (not `streamResult`), the Java stream yields `T`
+directly and all errors are terminal — they surface as exceptions from `Iterator.next()` or `Iterator.hasNext()`.
+
+### Push-based adapter using `java.util.concurrent.Flow`
+
+The push-based API is a convenience adapter built on top of the pull-based `HieroStream<T>`. It implements
+`java.util.concurrent.Flow.Publisher<T>` (Java 9+) so that consumers can use the standard reactive streams interface.
+The adapter contains no domain logic — it drives the pull loop on a virtual thread and delivers items to the
+`Flow.Subscriber`. See [java-files/HieroPublisher.java](java-files/HieroPublisher.java) and
+[java-files/HieroSubscription.java](java-files/HieroSubscription.java) for the full source with Javadoc.
+
+#### The `HieroPublisher<T>` adapter
+
+```java
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class HieroPublisher<T> implements Flow.Publisher<T> {
+
+    private final HieroStream<T> stream;
+
+    public HieroPublisher(@NonNull final HieroStream<T> stream) {
+        this.stream = Objects.requireNonNull(stream, "stream must not be null");
+    }
+
+    @Override
+    public void subscribe(@NonNull final Flow.Subscriber<? super T> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber must not be null");
+        subscriber.onSubscribe(new HieroSubscription<>(stream, subscriber));
+    }
+}
+```
+
+#### The `HieroSubscription<T>` implementation
+
+The subscription drives the pull-based `HieroStream` on a virtual thread and respects backpressure through the
+`Flow.Subscription.request(long)` protocol:
+
+```java
+final class HieroSubscription<T> implements Flow.Subscription {
+
+    private final HieroStream<T> stream;
+    private final Flow.Subscriber<? super T> subscriber;
+    private final AtomicLong requested = new AtomicLong(0);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    HieroSubscription(@NonNull final HieroStream<T> stream,
+                      @NonNull final Flow.Subscriber<? super T> subscriber) {
+        this.stream = stream;
+        this.subscriber = subscriber;
+        Thread.ofVirtual().start(this::drainLoop);
+    }
+
+    @Override
+    public void request(final long n) {
+        if (n <= 0) {
+            cancel();
+            subscriber.onError(new IllegalArgumentException("request count must be positive"));
+            return;
+        }
+        requested.addAndGet(n);
+    }
+
+    @Override
+    public void cancel() {
+        if (cancelled.compareAndSet(false, true)) {
+            stream.close();
+        }
+    }
+
+    private void drainLoop() {
+        try {
+            for (T item : stream) {
+                // Wait until demand is available
+                while (requested.get() <= 0) {
+                    if (cancelled.get()) {
+                        return;
+                    }
+                    Thread.sleep(1); // virtual thread parks cheaply
+                }
+                if (cancelled.get()) {
+                    return;
+                }
+                requested.decrementAndGet();
+                subscriber.onNext(item);
+            }
+            if (!cancelled.get()) {
+                subscriber.onComplete();
+            }
+        } catch (final Exception e) {
+            if (!cancelled.get()) {
+                subscriber.onError(e);
+            }
+        }
+    }
+}
+```
+
+#### Consumer usage with `Flow.Subscriber`
+
+```
+HieroStream<StreamItem<TopicMessage>> pullStream = topicSubscription.subscribe(client);
+Flow.Publisher<StreamItem<TopicMessage>> publisher = new HieroPublisher<>(pullStream);
+
+publisher.subscribe(new Flow.Subscriber<>() {
+
+    private Flow.Subscription subscription;
+
+    @Override
+    public void onSubscribe(@NonNull final Flow.Subscription subscription){
+        this.subscription = subscription;
+        subscription.request(1); // request first item
+    }
+
+    @Override
+    public void onNext(@NonNull final StreamItem<TopicMessage> item){
+        switch (item) {
+            case StreamItem.Success<TopicMessage> s -> process(s.value());
+            case StreamItem.Error<TopicMessage> e -> log.warn("Bad message", e.error());
+        }
+        subscription.request(1); // request next item
+    }
+
+    @Override
+    public void onError(@NonNull final Throwable throwable){
+        log.error("Stream failed", throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        log.info("Stream completed");
+    }
+});
+```
+
+#### Integration with reactive libraries
+
+Since `HieroPublisher<T>` implements the standard `java.util.concurrent.Flow.Publisher<T>` interface, it integrates
+directly with any reactive library that supports the Reactive Streams specification:
+
+```
+// Project Reactor (via JdkFlowAdapter)
+
+import reactor.adapter.JdkFlowAdapter;
+
+Flux<StreamItem<TopicMessage>> flux = JdkFlowAdapter.flowPublisherToFlux(
+        new HieroPublisher<>(topicSubscription.subscribe(client)));
+flux.filter(item ->item instanceof StreamItem.Success)
+        .map(item ->((StreamItem.Success<TopicMessage>)item).value())
+        .subscribe(msg ->process(msg));
+```
+
+```java
+// RxJava 3 (via jdk9-interop)
+
+import hu.akarnokd.rxjava3.jdkinterop.FlowInterop;
+
+Flowable<StreamItem<TopicMessage>> flowable = FlowInterop.fromFlowPublisher(
+        new HieroPublisher<>(topicSubscription.subscribe(client))
+);
+```
+
+### Why `Flow` over callbacks
+
+The Java `Flow` API (JSR 166, `java.util.concurrent.Flow`) was chosen over a custom callback interface for the
+push-based
+adapter because:
+
+1. **Standard library** — `Flow` is part of `java.base` since Java 9. No external dependency.
+2. **Backpressure built in** — The `request(n)` protocol prevents the producer from overwhelming the consumer. A custom
+   callback interface would need to reinvent this.
+3. **Reactive Streams interop** — `Flow.Publisher` is the Java standard mapping of the Reactive Streams specification.
+   It integrates directly with Project Reactor, RxJava, Vert.x, and any other reactive library via adapter utilities.
+4. **Well-understood contract** — The `Flow` specification defines clear rules for `onSubscribe`, `onNext`, `onError`,
+   and `onComplete` ordering, thread safety, and cancellation. A custom callback interface would need to document and
+   enforce all of these from scratch.
+
+### Architecture: pull is canonical, push is derived
+
+The pull-based `HieroStream<T>` is the single source of truth for all streaming logic. The push-based
+`HieroPublisher<T>`
+is a stateless adapter that drives the pull loop. This means:
+
+- All retry, reconnect, and node selection logic is implemented once in the pull stream.
+- The push adapter contains zero domain logic — it only bridges pull to push.
+- Bug fixes and improvements to streaming behavior apply to both consumption modes automatically.
+- SDK implementors only need to implement `HieroStream<T>`. The push adapter is provided by the SDK framework.
+
+```
+Network (gRPC/WebSocket) → SDK internal retry/reconnect → HieroStream<T> (pull)
+                                                              ↓
+                                                         HieroPublisher<T> (push adapter)
+                                                              ↓
+                                                         Flow.Subscriber<T> (consumer)
+```
+
+### Providing both APIs from a single method
+
+Streaming methods in the SDK should provide a pull-based return type as the primary API. The push-based `Publisher` can
+be obtained by wrapping the pull stream. A convenience method may be provided:
+
+```java
+public interface TopicSubscription {
+
+    // Primary: pull-based
+    @NonNull
+    HieroStream<StreamItem<TopicMessage>> subscribe(@NonNull Client client);
+
+    // Convenience: push-based adapter
+    @NonNull
+    default Flow.Publisher<StreamItem<TopicMessage>> subscribePublisher(@NonNull final Client client) {
+        return new HieroPublisher<>(subscribe(client));
+    }
+}
+```
+
+### Error handling summary
+
+| Error level    | Pull-based (`HieroStream`)                     | Push-based (`Flow.Publisher`)             |
+|----------------|------------------------------------------------|-------------------------------------------|
+| Per-item error | `StreamItem.Error` variant in the iteration    | `StreamItem.Error` delivered via `onNext` |
+| Stream-level   | Exception from `Iterator.next()` / `hasNext()` | Delivered via `onError`                   |
+| Cancellation   | `close()` / try-with-resources                 | `Subscription.cancel()`                   |
 
 ## Questions & Comments
 

--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -47,6 +47,7 @@ The following basic data types should be used in the API documentation.
 | `time`                     | A time value without date or timezone (nanosecond precision)          |
 | `dateTime`                 | A date and time value without timezone (nanosecond precision)         |
 | `zonedDateTime`            | A date and time value with timezone (nanosecond precision)            |
+| `streamResult<TYPE>`       | A stream item that is either a success value of TYPE or an error      |
 | `function<R m(p: T, ...)>` | A function type (often called lambda/callable)                        |
 
 ### Function Types
@@ -429,6 +430,152 @@ Example of a constant definition:
 namespace transactions
 
 constant MAX_TRANSACTIONS:int32 = 100
+```
+
+### Streaming
+
+The meta-language supports declaring methods that return an asynchronous stream of items. A stream is a pull-based async
+sequence that the consumer drives at its own pace. The SDK produces items (from a network subscription, gRPC stream,
+paginated query, etc.) and the consumer pulls them one at a time using the language's idiomatic async iteration construct.
+
+#### The `@@streaming` annotation
+
+The `@@streaming` annotation on a method declares that the method returns an asynchronous stream of items instead of a
+single value. The return type specifies the element type of the stream.
+
+```
+@@streaming
+TopicMessage subscribe(topicId: string)
+```
+
+The consumer iterates over the stream using the language's native async iteration pattern (e.g., `for await...of` in
+TypeScript, `async for` in Python, `while let Some(x) = s.next().await` in Rust). Breaking out of the loop cancels the
+stream.
+
+`@@streaming` applies only to method declarations. It must not be combined with `@@async` — a streaming method already
+implies asynchronous production of items. `@@async` is for single-value returns; `@@streaming` is for multi-value
+returns.
+
+#### Per-item error handling with `streamResult<TYPE>`
+
+Streams use a dedicated result wrapper to separate per-item errors (non-terminal) from stream-level errors (terminal).
+The `streamResult<TYPE>` data type represents a single item in the stream that is either a success value or an error:
+
+| Data Type             | Description                                                       |
+|-----------------------|-------------------------------------------------------------------|
+| `streamResult<TYPE>`  | A stream item that is either a success value of TYPE or an error  |
+
+A streaming method that may produce per-item errors uses `streamResult` as its return type:
+
+```
+@@streaming
+streamResult<TopicMessage> subscribe(topicId: string)
+```
+
+Each language maps `streamResult<TYPE>` to its idiomatic result/either type:
+
+| Language   | Mapping                                              |
+|------------|------------------------------------------------------|
+| Rust       | `Result<T, E>` (standard library)                    |
+| Swift      | `Result<T, Error>` (standard library)                |
+| Go         | `(T, error)` multiple return / `iter.Seq2[T, error]` |
+| C++        | `std::expected<T, E>` (C++23) / `absl::StatusOr<T>`  |
+| Java       | Sealed `StreamItem<T>` interface                     |
+| TypeScript | Discriminated union `{ ok: true, value: T } \| { ok: false, error: Error }` |
+| JavaScript | Plain object with `status` field                     |
+| Python     | `Success[T] \| Failure` dataclass union              |
+
+When a streaming method does **not** use `streamResult` (i.e., the return type is a plain type), all errors are
+stream-level and terminal — the stream ends and the error is delivered through the language's native error mechanism
+(exception, panic, etc.).
+
+#### Error levels in streams
+
+Streams have two distinct error levels:
+
+1. **Per-item errors** (non-terminal) — A single item in the stream is broken (parse error, invalid data, etc.). The
+   stream continues. These are expressed by yielding an error variant of `streamResult`.
+2. **Stream-level errors** (terminal) — The stream itself has failed (connection lost after retries exhausted, resource
+   deleted, authorization revoked). The stream ends. These are delivered through the language's native error mechanism.
+
+Consumer code follows a consistent two-level pattern:
+
+```
+try {
+    for await (item in stream) {
+        if (item is error) {
+            // per-item: handle, skip, or log
+        } else {
+            process(item.value)
+        }
+    }
+} catch (error) {
+    // stream-level: fatal, stream is over
+}
+```
+
+#### Retry strategy
+
+Retry and reconnection logic for transient failures (network interruptions, gRPC stream resets) is an SDK-internal
+concern. The SDK handles reconnection transparently — the consumer's iteration loop continues without interruption.
+
+User-facing retry configuration is expressed as parameters on the streaming method or on the object that provides the
+streaming method, not as control flow around the iteration loop:
+
+```
+@@streaming
+streamResult<TopicMessage> subscribe(topicId: string, @@nullable retryPolicy: RetryPolicy)
+```
+
+If the SDK exhausts its retry budget, the failure surfaces as a terminal stream-level error.
+
+#### Cancellation
+
+Cancellation is implicit: when the consumer stops iterating (breaks out of the loop, the enclosing scope ends, or the
+stream handle is explicitly closed/dropped), the SDK must release the underlying resources (close the gRPC stream,
+unsubscribe from the topic, etc.). Each language implements this through its native resource management:
+
+- **Rust**: Dropping the `Stream`
+- **Swift**: Task cancellation / leaving the `for await` scope
+- **Go**: Cancelling the `context.Context`
+- **Java**: `AutoCloseable.close()` / try-with-resources
+- **TypeScript/JavaScript**: `break` / `return` from the `for await` loop
+- **Python**: `break` / `return` from the `async for` loop, or async context manager
+- **C++**: RAII destructor
+
+#### Streaming annotation combinations
+
+`@@streaming` can be combined with the following annotations:
+
+- `@@throws(error-type)` — Declares terminal stream-level errors that the stream can produce.
+
+`@@streaming` must **not** be combined with:
+
+- `@@async` — Streaming already implies async item production.
+- `@@static` — Streams are produced by instances, not types.
+
+#### Full example
+
+```
+namespace topics
+requires common
+
+TopicSubscription {
+    @@streaming
+    @@throws(topic-deleted-error, authorization-error)
+    streamResult<TopicMessage> subscribe(topicId: common.TopicId, @@nullable retryPolicy: RetryPolicy)
+}
+
+TopicMessage {
+    @@immutable sequenceNumber: int64
+    @@immutable payload: bytes
+    @@immutable timestamp: zonedDateTime
+}
+
+RetryPolicy {
+    @@immutable @@default(3) maxAttempts: int32
+    @@immutable @@default("exponential") backoffStrategy: string
+}
 ```
 
 ### Best practices and antipatterns

--- a/guides/java-files/HieroPublisher.java
+++ b/guides/java-files/HieroPublisher.java
@@ -1,0 +1,114 @@
+package org.hiero.sdk;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+
+/**
+ * A push-based adapter that wraps a pull-based {@link HieroStream} as a
+ * {@link java.util.concurrent.Flow.Publisher}. This enables consumers to use the standard
+ * Reactive Streams protocol for push-based consumption, while all domain logic (retry, reconnect,
+ * error handling) remains in the underlying pull-based {@code HieroStream}.
+ *
+ * <p>This adapter contains <strong>no domain logic</strong>. It drives the pull loop on a virtual
+ * thread (Java 21+) and delivers items to the {@link Flow.Subscriber} according to the
+ * Reactive Streams specification. Backpressure is respected through the
+ * {@link Flow.Subscription#request(long)} protocol — items are only delivered when the subscriber
+ * has outstanding demand.
+ *
+ * <p><strong>Architecture:</strong>
+ * <pre>
+ * Network (gRPC/WebSocket)
+ *     → SDK internal retry/reconnect
+ *         → HieroStream&lt;T&gt; (pull — canonical implementation)
+ *             → HieroPublisher&lt;T&gt; (push adapter — this class)
+ *                 → Flow.Subscriber&lt;T&gt; (consumer)
+ * </pre>
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>{@code
+ * HieroStream<StreamItem<TopicMessage>> pullStream = subscription.subscribe(client);
+ * Flow.Publisher<StreamItem<TopicMessage>> publisher = new HieroPublisher<>(pullStream);
+ *
+ * publisher.subscribe(new Flow.Subscriber<>() {
+ *     private Flow.Subscription subscription;
+ *
+ *     @Override
+ *     public void onSubscribe(Flow.Subscription subscription) {
+ *         this.subscription = subscription;
+ *         subscription.request(1);
+ *     }
+ *
+ *     @Override
+ *     public void onNext(StreamItem<TopicMessage> item) {
+ *         switch (item) {
+ *             case StreamItem.Success<TopicMessage> s -> process(s.value());
+ *             case StreamItem.Error<TopicMessage> e -> log.warn("Bad message", e.error());
+ *         }
+ *         subscription.request(1);
+ *     }
+ *
+ *     @Override
+ *     public void onError(Throwable throwable) {
+ *         log.error("Stream failed", throwable);
+ *     }
+ *
+ *     @Override
+ *     public void onComplete() {
+ *         log.info("Stream completed");
+ *     }
+ * });
+ * }</pre>
+ *
+ * <p><strong>Reactive library integration:</strong>
+ * <p>Since this class implements {@link Flow.Publisher}, it integrates directly with any reactive
+ * library that supports the Reactive Streams specification:
+ * <ul>
+ *   <li>Project Reactor: {@code JdkFlowAdapter.flowPublisherToFlux(publisher)}</li>
+ *   <li>RxJava 3: {@code FlowInterop.fromFlowPublisher(publisher)}</li>
+ * </ul>
+ *
+ * <p><strong>Thread safety:</strong> Each call to {@link #subscribe(Flow.Subscriber)} creates an
+ * independent subscription with its own virtual thread. The publisher itself is stateless and can
+ * be shared across threads. However, the underlying {@link HieroStream} supports only a single
+ * subscriber — calling {@code subscribe} more than once on the same publisher will fail because
+ * the stream's iterator can only be obtained once.
+ *
+ * @param <T> the type of elements published. When per-item error handling is needed, this is
+ *            typically {@link StreamItem StreamItem&lt;V&gt;} where {@code V} is the value type.
+ * @see HieroStream
+ * @see StreamItem
+ * @see <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-guideline.md">
+ *     API Guideline — @@streaming</a>
+ */
+public final class HieroPublisher<T> implements Flow.Publisher<T> {
+
+    private final HieroStream<T> stream;
+
+    /**
+     * Creates a new publisher that wraps the given pull-based stream.
+     *
+     * @param stream the pull-based stream to adapt; must not be null
+     * @throws NullPointerException if {@code stream} is null
+     */
+    public HieroPublisher(@NonNull final HieroStream<T> stream) {
+        this.stream = Objects.requireNonNull(stream, "stream must not be null");
+    }
+
+    /**
+     * Subscribes the given subscriber to this publisher. A virtual thread is started to drive the
+     * pull loop and deliver items to the subscriber according to the Reactive Streams protocol.
+     *
+     * <p>The subscriber's {@link Flow.Subscriber#onSubscribe(Flow.Subscription)} method is called
+     * synchronously before this method returns, providing the subscription through which the
+     * subscriber can request items and cancel.
+     *
+     * @param subscriber the subscriber to receive items; must not be null
+     * @throws NullPointerException if {@code subscriber} is null
+     */
+    @Override
+    public void subscribe(@NonNull final Flow.Subscriber<? super T> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber must not be null");
+        final HieroSubscription<T> subscription = new HieroSubscription<>(stream, subscriber);
+        subscriber.onSubscribe(subscription);
+    }
+}

--- a/guides/java-files/HieroStream.java
+++ b/guides/java-files/HieroStream.java
@@ -1,0 +1,87 @@
+package org.hiero.sdk;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * A pull-based asynchronous stream of items. This is the primary streaming interface in the Hiero SDK.
+ * Consumers iterate over items using a standard {@code for} loop or {@link Iterator}, and the stream
+ * is cancelled and cleaned up by calling {@link #close()} — typically via try-with-resources.
+ *
+ * <p>{@code HieroStream} extends {@link Iterable} so it can be used in enhanced {@code for} loops,
+ * and {@link AutoCloseable} so it integrates with try-with-resources for automatic resource cleanup.
+ * When closed, the stream releases all underlying resources (gRPC connections, network subscriptions,
+ * internal buffers, etc.).
+ *
+ * <p>The {@link Iterator} returned by {@link #iterator()} blocks on {@link Iterator#next()} until
+ * the next item is available. On Java 21+, this is efficient when consumed on a virtual thread —
+ * the virtual thread parks without blocking an OS thread. On older Java versions, the consumer
+ * thread blocks, which is acceptable for most use cases since stream processing typically dedicates
+ * a thread to consumption.
+ *
+ * <p>A {@code HieroStream} must only be iterated once. Calling {@link #iterator()} a second time
+ * must throw {@link IllegalStateException}.
+ *
+ * <p><strong>Pull-based usage (primary):</strong>
+ * <pre>{@code
+ * try (HieroStream<StreamItem<TopicMessage>> stream = subscription.subscribe(client)) {
+ *     for (StreamItem<TopicMessage> item : stream) {
+ *         switch (item) {
+ *             case StreamItem.Success<TopicMessage> s -> process(s.value());
+ *             case StreamItem.Error<TopicMessage> e -> log.warn("Bad message", e.error());
+ *         }
+ *     }
+ * } // close() cancels the stream and releases resources
+ * }</pre>
+ *
+ * <p><strong>Push-based usage (convenience adapter):</strong>
+ * <p>A {@code HieroStream} can be wrapped in a {@link HieroPublisher} to obtain a
+ * {@link java.util.concurrent.Flow.Publisher} for push-based consumption via the standard
+ * Reactive Streams protocol. The push adapter contains no domain logic — all retry, reconnect,
+ * and error handling logic lives in the pull-based {@code HieroStream} implementation.
+ *
+ * <p><strong>Thread safety:</strong> A {@code HieroStream} is not thread-safe. It must be consumed
+ * by a single thread (or a single virtual thread). Concurrent iteration from multiple threads
+ * produces undefined behavior.
+ *
+ * @param <T> the type of elements in the stream. When per-item error handling is needed, this is
+ *            typically {@link StreamItem StreamItem&lt;V&gt;} where {@code V} is the value type.
+ * @see StreamItem
+ * @see HieroPublisher
+ * @see <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-guideline.md">
+ *     API Guideline — @@streaming</a>
+ */
+public interface HieroStream<T> extends Iterable<T>, AutoCloseable {
+
+    /**
+     * Returns an iterator over the items in this stream. The iterator blocks on {@link Iterator#next()}
+     * until the next item is available or the stream ends.
+     *
+     * <p>This method must only be called once. A second call must throw {@link IllegalStateException}
+     * to prevent multiple consumers from reading the same stream concurrently.
+     *
+     * <p>The iterator signals stream completion by returning {@code false} from {@link Iterator#hasNext()}.
+     * Terminal stream-level errors are thrown as exceptions from {@link Iterator#hasNext()} or
+     * {@link Iterator#next()}.
+     *
+     * @return a non-null iterator over the stream items
+     * @throws IllegalStateException if {@code iterator()} has already been called on this stream
+     */
+    @Override
+    Iterator<T> iterator();
+
+    /**
+     * Cancels the stream and releases all underlying resources. After this method returns, no further
+     * items will be produced and the underlying network connection (gRPC stream, WebSocket, etc.) is
+     * closed.
+     *
+     * <p>This method is idempotent — calling it multiple times has no additional effect. It does not
+     * throw exceptions. If the stream has already completed naturally, calling {@code close()} is a
+     * no-op.
+     *
+     * <p>When used with try-with-resources, {@code close()} is called automatically when the block
+     * exits, whether normally or due to an exception.
+     */
+    @Override
+    void close();
+}

--- a/guides/java-files/HieroSubscription.java
+++ b/guides/java-files/HieroSubscription.java
@@ -1,0 +1,133 @@
+package org.hiero.sdk;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link Flow.Subscription} implementation that drives a pull-based {@link HieroStream} on a virtual
+ * thread and delivers items to a {@link Flow.Subscriber} with backpressure support. This class is the
+ * bridge between the pull-based and push-based streaming models in the Hiero SDK.
+ *
+ * <p>This class is package-private and not part of the public API. It is used internally by
+ * {@link HieroPublisher} to adapt a {@code HieroStream} into a {@code Flow.Publisher}.
+ *
+ * <p><strong>Backpressure:</strong> Items are only delivered to the subscriber when there is outstanding
+ * demand via {@link #request(long)}. If the subscriber has not requested any items, the virtual thread
+ * parks until demand becomes available or the subscription is cancelled. This ensures the subscriber
+ * is never overwhelmed by a fast producer.
+ *
+ * <p><strong>Cancellation:</strong> Calling {@link #cancel()} closes the underlying {@code HieroStream}
+ * and stops the virtual thread. The cancellation is cooperative — the drain loop checks the cancelled
+ * flag before delivering each item. Cancellation is idempotent.
+ *
+ * <p><strong>Terminal signals:</strong>
+ * <ul>
+ *   <li>When the stream completes naturally (iterator exhausted), {@link Flow.Subscriber#onComplete()}
+ *       is called.</li>
+ *   <li>When the stream throws an exception (terminal stream-level error),
+ *       {@link Flow.Subscriber#onError(Throwable)} is called.</li>
+ *   <li>Neither terminal signal is sent after cancellation.</li>
+ * </ul>
+ *
+ * <p><strong>Threading:</strong> The drain loop runs on a virtual thread (Java 21+). The virtual thread
+ * parks cheaply when waiting for demand, without blocking an OS thread. The subscriber's
+ * {@code onNext}, {@code onError}, and {@code onComplete} methods are called from this virtual thread.
+ *
+ * @param <T> the type of elements delivered to the subscriber
+ * @see HieroPublisher
+ * @see HieroStream
+ * @see <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-guideline.md">
+ *     API Guideline — @@streaming</a>
+ */
+final class HieroSubscription<T> implements Flow.Subscription {
+
+    private final HieroStream<T> stream;
+    private final Flow.Subscriber<? super T> subscriber;
+    private final AtomicLong requested = new AtomicLong(0);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    /**
+     * Creates a new subscription and immediately starts a virtual thread to drive the pull loop.
+     *
+     * @param stream     the pull-based stream to drain; must not be null
+     * @param subscriber the subscriber to deliver items to; must not be null
+     */
+    HieroSubscription(@NonNull final HieroStream<T> stream,
+                      @NonNull final Flow.Subscriber<? super T> subscriber) {
+        this.stream = Objects.requireNonNull(stream, "stream must not be null");
+        this.subscriber = Objects.requireNonNull(subscriber, "subscriber must not be null");
+        Thread.ofVirtual().name("hiero-stream-publisher").start(this::drainLoop);
+    }
+
+    /**
+     * Requests {@code n} more items from the stream. The drain loop will deliver up to {@code n}
+     * additional items to the subscriber before waiting for more demand.
+     *
+     * <p>If {@code n} is not positive, the subscription is cancelled and
+     * {@link Flow.Subscriber#onError(Throwable)} is called with an {@link IllegalArgumentException},
+     * as required by the Reactive Streams specification.
+     *
+     * @param n the number of items to request; must be positive
+     */
+    @Override
+    public void request(final long n) {
+        if (n <= 0) {
+            cancel();
+            subscriber.onError(new IllegalArgumentException(
+                    "Flow.Subscription.request requires a positive count, got: " + n));
+            return;
+        }
+        requested.addAndGet(n);
+    }
+
+    /**
+     * Cancels the subscription. Closes the underlying {@link HieroStream} and signals the drain loop
+     * to stop. After cancellation, no further items or terminal signals are delivered to the subscriber.
+     *
+     * <p>This method is idempotent — calling it multiple times has no additional effect. It is safe
+     * to call from any thread.
+     */
+    @Override
+    public void cancel() {
+        if (cancelled.compareAndSet(false, true)) {
+            stream.close();
+        }
+    }
+
+    /**
+     * The main loop that pulls items from the {@link HieroStream} and delivers them to the subscriber.
+     * This method runs on a virtual thread started in the constructor.
+     *
+     * <p>The loop respects backpressure by waiting for outstanding demand before delivering each item.
+     * It checks the cancellation flag before each delivery to ensure prompt shutdown.
+     */
+    private void drainLoop() {
+        try {
+            final Iterator<T> iterator = stream.iterator();
+            while (iterator.hasNext()) {
+                while (requested.get() <= 0) {
+                    if (cancelled.get()) {
+                        return;
+                    }
+                    Thread.sleep(1); // virtual thread parks cheaply
+                }
+                if (cancelled.get()) {
+                    return;
+                }
+                final T item = iterator.next();
+                requested.decrementAndGet();
+                subscriber.onNext(item);
+            }
+            if (!cancelled.get()) {
+                subscriber.onComplete();
+            }
+        } catch (final Exception e) {
+            if (!cancelled.get()) {
+                subscriber.onError(e);
+            }
+        }
+    }
+}

--- a/guides/java-files/StreamItem.java
+++ b/guides/java-files/StreamItem.java
@@ -1,0 +1,78 @@
+package org.hiero.sdk;
+
+import java.util.Objects;
+
+/**
+ * A sealed result type representing a single item in a {@link HieroStream} that is either a success
+ * value or an error. This is the Java mapping of the meta-language {@code streamResult<TYPE>}.
+ *
+ * <p>{@code StreamItem} enables per-item error handling in streams without terminating the stream.
+ * When the SDK encounters a problem with an individual item (e.g., a malformed message, a parse error,
+ * or invalid data), it yields a {@link Error} variant instead of throwing an exception. The stream
+ * continues producing subsequent items. Terminal stream-level errors (connection lost, authorization
+ * revoked) are not represented as {@code StreamItem} — they are thrown as exceptions from the
+ * stream's iterator.
+ *
+ * <p><strong>Error levels in streams:</strong>
+ * <ul>
+ *   <li><strong>Per-item errors (non-terminal):</strong> Represented as {@link Error} variants.
+ *       The stream continues. The consumer decides how to handle each error (skip, log, collect, abort).</li>
+ *   <li><strong>Stream-level errors (terminal):</strong> Thrown as exceptions from
+ *       {@link java.util.Iterator#next()} or {@link java.util.Iterator#hasNext()}. The stream is over.</li>
+ * </ul>
+ *
+ * <p><strong>Usage with pattern matching (Java 17+):</strong>
+ * <pre>{@code
+ * try (HieroStream<StreamItem<TopicMessage>> stream = subscription.subscribe(client)) {
+ *     for (StreamItem<TopicMessage> item : stream) {
+ *         switch (item) {
+ *             case StreamItem.Success<TopicMessage> s -> process(s.value());
+ *             case StreamItem.Error<TopicMessage> e -> {
+ *                 if (e.error() instanceof ThrottleException throttle) {
+ *                     log.info("Throttled, retryAfter={}", throttle.getRetryAfter());
+ *                 } else {
+ *                     log.warn("Item error: {}", e.error().getMessage());
+ *                 }
+ *             }
+ *         }
+ *     }
+ * } catch (TopicDeletedException ex) {
+ *     // Terminal stream-level error
+ *     log.error("Topic was deleted", ex);
+ * }
+ * }</pre>
+ *
+ * @param <T> the type of the success value
+ * @see HieroStream
+ * @see <a href="https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/api-guideline.md">
+ *     API Guideline — streamResult</a>
+ */
+public sealed interface StreamItem<T> permits StreamItem.Success, StreamItem.Error {
+
+    /**
+     * A successful stream item containing a value.
+     *
+     * @param value the non-null success value
+     * @param <T>   the type of the success value
+     */
+    record Success<T>(@NonNull T value) implements StreamItem<T> {
+
+        public Success {
+            Objects.requireNonNull(value, "value must not be null");
+        }
+    }
+
+    /**
+     * A failed stream item containing an error. The stream continues after yielding this item —
+     * the error is non-terminal. The consumer decides whether to skip, log, collect, or abort.
+     *
+     * @param error the non-null error that caused this item to fail
+     * @param <T>   the type of the success value (not present in this variant)
+     */
+    record Error<T>(@NonNull Throwable error) implements StreamItem<T> {
+
+        public Error {
+            Objects.requireNonNull(error, "error must not be null");
+        }
+    }
+}


### PR DESCRIPTION
This pull request makes several improvements to the Java API best practices documentation, primarily by adding comprehensive guidance on implementing streaming APIs in Java and clarifying the canonical type mappings. The changes standardize how asynchronous streams should be exposed in the SDK, introduce new interfaces and adapters for both pull- and push-based streaming, and update the documentation to reflect these new patterns.