### PR TITLE
feat: add NFT service API definition and methods for NFT management

### DIFF
--- a/guides/api-guideline.md
+++ b/guides/api-guideline.md
@@ -40,6 +40,7 @@ The following basic data types should be used in the API documentation.
 | `bytes`                    | A sequence of bytes                                                   |
 | `list<TYPE>`               | A list of elements of type TYPE                                       |
 | `set<TYPE>`                | A set of elements of type TYPE                                        |
+| `collection<TYPE>`         | A collection of elements of type TYPE                                 |
 | `map<KEY, VALUE>`          | A map that maps KEY values to VALUE values                            |
 | `type`                     | A type identity that can be used to specify a complex type at runtime |
 | `uuid`                     | A universally unique identifier                                       |
@@ -510,7 +511,8 @@ constant MAX_TRANSACTIONS:int32 = 100
 
 The meta-language supports declaring methods that return an asynchronous stream of items. A stream is a pull-based async
 sequence that the consumer drives at its own pace. The SDK produces items (from a network subscription, gRPC stream,
-paginated query, etc.) and the consumer pulls them one at a time using the language's idiomatic async iteration construct.
+paginated query, etc.) and the consumer pulls them one at a time using the language's idiomatic async iteration
+construct.
 
 #### The `@@streaming` annotation
 
@@ -535,9 +537,9 @@ returns.
 Streams use a dedicated result wrapper to separate per-item errors (non-terminal) from stream-level errors (terminal).
 The `streamResult<TYPE>` data type represents a single item in the stream that is either a success value or an error:
 
-| Data Type             | Description                                                       |
-|-----------------------|-------------------------------------------------------------------|
-| `streamResult<TYPE>`  | A stream item that is either a success value of TYPE or an error  |
+| Data Type            | Description                                                      |
+|----------------------|------------------------------------------------------------------|
+| `streamResult<TYPE>` | A stream item that is either a success value of TYPE or an error |
 
 A streaming method that may produce per-item errors uses `streamResult` as its return type:
 
@@ -548,16 +550,16 @@ streamResult<TopicMessage> subscribe(topicId: string)
 
 Each language maps `streamResult<TYPE>` to its idiomatic result/either type:
 
-| Language   | Mapping                                              |
-|------------|------------------------------------------------------|
-| Rust       | `Result<T, E>` (standard library)                    |
-| Swift      | `Result<T, Error>` (standard library)                |
-| Go         | `(T, error)` multiple return / `iter.Seq2[T, error]` |
-| C++        | `std::expected<T, E>` (C++23) / `absl::StatusOr<T>`  |
-| Java       | Sealed `StreamItem<T>` interface                     |
+| Language   | Mapping                                                                     |
+|------------|-----------------------------------------------------------------------------|
+| Rust       | `Result<T, E>` (standard library)                                           |
+| Swift      | `Result<T, Error>` (standard library)                                       |
+| Go         | `(T, error)` multiple return / `iter.Seq2[T, error]`                        |
+| C++        | `std::expected<T, E>` (C++23) / `absl::StatusOr<T>`                         |
+| Java       | Sealed `StreamItem<T>` interface                                            |
 | TypeScript | Discriminated union `{ ok: true, value: T } \| { ok: false, error: Error }` |
-| JavaScript | Plain object with `status` field                     |
-| Python     | `Success[T] \| Failure` dataclass union              |
+| JavaScript | Plain object with `status` field                                            |
+| Python     | `Success[T] \| Failure` dataclass union                                     |
 
 When a streaming method does **not** use `streamResult` (i.e., the return type is a plain type), all errors are
 stream-level and terminal — the stream ends and the error is delivered through the language's native error mechanism

--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -14,21 +14,21 @@ namespace client
 requires common, config, keys
 
 // Definition of an account that signs and pays for requests
-OperatorAccount {
+Account {
     @@immutable accountId: common.AccountId // the account id of the operator
     @@immutable privateKey: keys.PrivateKey // the private key of the operator
 }
 
 // The client API that will be used by the SDK to interact with the network
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
+    @@immutable operatorAccount: Account // the operator account
     @@immutable ledger: common.Ledger // the network to connect to
     // TO_BE_DEFINED_IN_FUTURE_VERSIONS
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: Account)
 ```
 
 ## Examples
@@ -38,9 +38,9 @@ The following example shows how to create a `HieroClient` instance:
 ```
 AccountId accountId = ...;
 PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Account Account = new OperatorAccount(accountId, privateKey);
 
-NetworkSetting networkSettings = ...;
+NetworkSetting networkSettings = NetworkSetting.getNetworkSetting(HEDERA_TESTNET_IDENTIFIER);
 
 HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
 ```

--- a/v3-sandbox/prototype-api/common.md
+++ b/v3-sandbox/prototype-api/common.md
@@ -69,6 +69,9 @@ MirrorNode {
     @@immutable restBaseUrl: string // base url of the mirror node REST API (scheme://host[:port]/api/v1)
 }
 
+BlockNode {
+}
+
 // Represents the base of an address on a network.
 abstraction Address {
     @@immutable shard: uint64 // shard number
@@ -94,6 +97,9 @@ ContractId extends Address {
 }
 
 FileId extends Address {
+}
+
+TokenId extends Address {
 }
 
 // factory methods of AccountId that should be added to the namespace in the best language dependent way

--- a/v3-sandbox/prototype-api/config.md
+++ b/v3-sandbox/prototype-api/config.md
@@ -28,6 +28,7 @@ NetworkSetting {
     // Modifications to the returned set do not affect the original
     @@immutable set<common.MirrorNode> getMirrorNodes()
 
+    @@immutable set<common.BlockNode> getBlockNodes()
 }
 
 // factory methods of `NetworkSetting` that should be added to the namespace in the best language dependent way

--- a/v3-sandbox/prototype-api/service-nft.md
+++ b/v3-sandbox/prototype-api/service-nft.md
@@ -1,0 +1,80 @@
+# NFT Service API
+
+Service definition for NFT interaction.
+
+## API Schema
+
+```
+namespace enterprise.service.nft
+requires common, keys, client
+
+NftType {
+    @immutable id:common.TokenId,
+    @immutable name:string,
+    @immutable symbol:string,
+    @immutable treasuryAccount:client.Account
+}
+
+NftId {
+    @immutable type:NftType,
+    @immutable serial:uint64
+}
+
+Nft extends NftId {
+    @immutable owner:common.AccountId,
+    @immutable metadata:bytes
+}
+
+NftService {
+
+    @@throws(service-error) @nullable NftType getNftType(id:common.TokenId)
+    
+    @@throws(service-error) @nullable Nft getNft(id:NftId);
+
+    @@throws(service-error) Page<NftType> findAllTypes()
+    
+    @@throws(service-error) Page<NftType> findTypesByOwner(ownerId:common.AccountId);
+
+    @@throws(service-error) Page<Nft> findByOwner(ownerId:common.AccountId);
+    
+    @@throws(service-error) Page<Nft> findByType(type:NftType);
+    
+    @@throws(service-error) Page<Nft> findByOwnerAndType(ownerId:common.AccountId, type:NftType);
+    
+    @@throws(service-error) NftType createNftType(name:string, symbol:string)
+    
+    @@throws(service-error) NftType createNftType(name:string, symbol:string, supplierKey:keys.PublicKey)
+    
+    @@throws(service-error) NftType createNftType(name:string, symbol:string, treasuryAccount:client.Account)
+    
+    @@throws(service-error) NftType createNftType(name:string, symbol:string, supplierKey:keys.PublicKey, treasuryAccount:client.Account)
+    
+    @@throws(service-error) void associateAccountToNftType(type:NftType, account:client.Account)
+    
+    @@throws(service-error) void associateAccountsToNftType(types:collection<NftType>, account:client.Account)
+    
+    @@throws(service-error) void dissociateAccountToNftType(type:NftType, account:client.Account)
+    
+    @@throws(service-error) void dissociateAccountsToNftType(types:collection<NftType>, account:client.Account)
+
+    @@throws(service-error) Nft mintNft(type:NftType, metadata:bytes)
+    
+    @@throws(service-error) Nft mintNft(type:NftType, supplierKey:keys.PublicKey, metadata:bytes)
+
+    @@throws(service-error) list<Nft> mintNfts(type:NftType, metadata:list<bytes>)
+
+    @@throws(service-error) list<Nft> mintNfts(type:NftType, supplierKey:keys.PublicKey, metadata:list<bytes>)
+
+    @@throws(service-error) void burnNft(nft:NftId)
+
+    @@throws(service-error) void burnNft(nft:NftId, supplierKey:keys.PublicKey)
+
+    @@throws(service-error) void burnNfts(nfts:collection<NftId>)
+
+    @@throws(service-error) void burnNfts(nfts:collection<NftId>, supplierKey:keys.PublicKey)
+    
+    @@throws(service-error) void transferNft(nft:NftId, fromAccount:client.Account, toAccountId:common.AccountId)
+    
+    @@throws(service-error) void transferNfts(nfts:collection<NftId>, fromAccount:client.Account, toAccountId:common.AccountId)
+}
+```

--- a/v3-sandbox/prototype-api/service.md
+++ b/v3-sandbox/prototype-api/service.md
@@ -7,4 +7,16 @@ The idea is to make it easier to use the SDK and to allow a better integration i
 
 ```
 namespace enterprise.service
+
+Page<T> {
+  @immutable pageIndex:int32;
+  @immutable size:int32;
+  @immutable data:list<T>;
+  @immutable hasNext:boolean;
+  @immutable isFirst:boolean;
+  
+  @async Page<T> next();
+  @async Page<T> first();
+}
+
 ```


### PR DESCRIPTION
This pull request introduces a new NFT Service API, expands the core data model, and improves API consistency and documentation. The most important changes are summarized below.

**New NFT Service API:**

* Added a comprehensive `NftService` API definition in `v3-sandbox/prototype-api/service-nft.md` for interacting with NFTs, including methods for querying, creating, minting, burning, transferring, and associating NFTs and NFT types.