### PR TITLE
docs(v3): define client namespace with HieroClient and Operator

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.


### PR DESCRIPTION
The `client.md` spec was a stub with a `TO_BE_DEFINED_IN_FUTURE_VERSIONS` placeholder and field names that did not align with how `transactions.md` already referenced the namespace. This fills it in.

The main changes: `OperatorAccount` is renamed to `Operator` to match the `sign(client.operator)` reference in `transactions.md`. The `ledger: common.Ledger` field is replaced with `network: config.NetworkSetting`, which is the type the rest of the API uses for network identity. A `close()` method is added since any client holding gRPC channels needs a way to release them. The single factory method is split into `create()` for direct construction and `forNetwork()` for the named-network pattern already established in `config.md`.

The existing `Questions & Comments` entry from @rwalworth is preserved and two new open questions are added covering execution config placement and async close semantics.

Tested by cross-referencing all `client.HieroClient` and `client.operator` usages in `transactions.md` and confirming they resolve against the updated spec.