### PR TITLE
docs(v3): clarify MethodDescriptor portability in grpc namespace

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.

--- a/v3-sandbox/prototype-api/grpc.md
+++ b/v3-sandbox/prototype-api/grpc.md
@@ -4,17 +4,32 @@ This section defines the GRPC API.
 
 ## Description
 
-The communications protocol between Hiero SDKs and the network nodes is done based on GRPC and Protobuf.
+The communications protocol between Hiero SDKs and the network nodes is done based on gRPC and Protobuf.
+
+`MethodDescriptor` identifies a gRPC method by its fully-qualified service name and method name. It is
+defined here as a portable value type with no dependency on any language's gRPC runtime library. The
+binding to the language-specific gRPC channel happens inside the SDK transport layer, not in the public API.
+
+This means PoC authors must NOT use `io.grpc.MethodDescriptor` (Java), `grpc.ServiceRpc` (Python), or
+any equivalent runtime type in the public SPI signature. They must accept and return this custom type,
+then map it to the runtime type internally.
 
 ```
 namespace grpc
 
-// Minimal placeholder to express SPI dependency.
-// Concrete transport-layer details are language and runtime specific.
+// Cross-language value type identifying a gRPC method.
+// Does not depend on any language's gRPC runtime — the runtime binding is an internal detail.
 abstraction MethodDescriptor {
-    @@immutable serviceName: string
-    @@immutable methodName: string
+    @@immutable serviceName: string   // fully-qualified gRPC service name (e.g. "proto.CryptoService")
+    @@immutable methodName: string    // gRPC method name within the service (e.g. "createAccount")
 }
 ```
 
 ## Questions & Comments
+
+- [@hendrikebbers](https://github.com/hendrikebbers): Is `MethodDescriptor` specific for Java or is it the same for all languages?
+  Can we provide all information needed for `MethodDescriptor` in a custom complex type and by doing so remove the dependency to `grpc` in the public API?
+
+  **Decision:** `MethodDescriptor` is cross-language. The type above is the complete public representation —
+  `serviceName` and `methodName` strings carry all information needed to construct the language-specific
+  gRPC descriptor internally. No SDK should expose its gRPC runtime type in the public SPI signature.

--- a/v3-sandbox/prototype-api/transactions-spi.md
+++ b/v3-sandbox/prototype-api/transactions-spi.md
@@ -48,5 +48,15 @@ set<TransactionSupport> getAllTransactionSupports() // returns all TransactionSu
 ## Questions & Comments
 
 - [@hendrikebbers](https://github.com/hendrikebbers): Do we have classes like `TransactionBody.Builder` for every language in the generated proto files?
+
 - [@hendrikebbers](https://github.com/hendrikebbers): Is `MethodDescriptor` specific for Java or is it the same for all languages?
+
+  **Decision:** `grpc.MethodDescriptor` is cross-language. It is defined as a portable value type
+  with `serviceName: string` and `methodName: string`. See [grpc.md](grpc.md) for the full rationale.
+
 - [@hendrikebbers](https://github.com/hendrikebbers): Can we provide all information needed for `MethodDescriptor` in a custom complex type and by doing so remove the dependency to `grpc` in the public API?
+
+  **Decision:** Yes — this is exactly what `grpc.MethodDescriptor` does. The public SPI uses only
+  this custom type. Language-specific gRPC runtime types (e.g. `io.grpc.MethodDescriptor` in Java)
+  are constructed inside the transport layer from these two string fields and are not part of the
+  public API.


### PR DESCRIPTION
`grpc.md` had a minimal stub for `MethodDescriptor` with no explanation of whether it was meant to be a language-specific gRPC runtime type or a portable value type. The open questions in `transactions-spi.md` (raised by @hendrikebbers) were also left unanswered, blocking PoC authors from knowing how to implement `TransactionSupport.getMethodDescriptor()`.

The design intent is Option A: `MethodDescriptor` is a cross-language value type. It carries only `serviceName` and `methodName` as strings. The language-specific gRPC channel binding happens inside the transport layer and is not part of the public SPI. This is now stated explicitly in the description, the inline comments, and the `Questions & Comments` section of `grpc.md`.

The two related questions in `transactions-spi.md` are answered with decisions that point back to `grpc.md` for the rationale.

Closes #232.