### PR TITLE
docs(v3): resolve Ledger vs Network naming in common namespace

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.

--- a/v3-sandbox/prototype-api/common.md
+++ b/v3-sandbox/prototype-api/common.md
@@ -51,9 +51,9 @@ HBarExchangeRate {
     bool isExpired()
 }
 
-// Represents a specific ledger instance
-Ledger {
-    @@immutable id: bytes // identifier of the ledger
+// Represents a specific network instance (e.g. Hedera mainnet, Hedera testnet, a custom Hiero network)
+Network {
+    @@immutable id: bytes // identifier of the network, as returned by the consensus node
     @@immutable @@nullable name: string // human readable name of the network
 }
 
@@ -77,7 +77,7 @@ abstraction Address {
     @@immutable checksum: string // checksum of the address
     
     // Validates the checksum of the address
-    bool validateChecksum(ledger: Ledger)
+    bool validateChecksum(network: Network)
     
     // returns address in format "shard.realm.num"
     string toString()
@@ -107,6 +107,10 @@ FileId extends Address {
 ## Questions & Comments
 
 - [@hendrikebbers](https://github.com/hendrikebbers): Should we rename `Ledger` to `Network`?
+  **Resolved**: Renamed to `Network`. Developer experience is a V3 design principle, and "Network" is immediately
+  understood by any developer regardless of DLT background. It is also consistent with the naming already used
+  in the `config` namespace (`NetworkSetting`, `getNetworkSetting`, `registerNetworkSetting`). All PoC authors
+  referring to `common.Ledger` should update to `common.Network`.
 - [@hendrikebbers](https://github.com/hendrikebbers): Do we want an abstraction for currency? HBAR is the only one for
   now and can be seen as Hedera specific.
 - [@hendrikebbers](https://github.com/hendrikebbers): Do we want to have separate types for `AccountId`, `ContractId`

--- a/v3-sandbox/prototype-api/config.md
+++ b/v3-sandbox/prototype-api/config.md
@@ -18,7 +18,7 @@ constant HEDERA_TESTNET_IDENTIFIER:string = "hedera-testnet" // identifier for t
 // The full configuration to connect to a specific network
 NetworkSetting {
  
-    @@immutable ledger: common.Ledger // the definition of the ledger
+    @@immutable network: common.Network // the network this setting connects to
    
     // Returns an immutable set of consensus nodes
     // Modifications to the returned set do not affect the original


### PR DESCRIPTION
Renames the `Ledger` type in the `common` namespace to `Network` and updates all references across `common.md` and `config.md`.

The open question posted by @hendrikebbers asked whether `Ledger` should be renamed to `Network`. The answer is yes, for two reasons. First, developer experience is a stated V3 design principle: "Network" is understood immediately by any developer, while "Ledger" is DLT jargon that creates friction for developers new to the Hiero ecosystem. Second, the `config` namespace already uses "Network" consistently (`NetworkSetting`, `getNetworkSetting`, `registerNetworkSetting`) — keeping `Ledger` as the underlying type name would introduce a conceptual mismatch.

Changes:

- `common.md`: `Ledger` renamed to `Network`, type comment updated to clarify scope (mainnet, testnet, custom Hiero network), `validateChecksum(ledger: Ledger)` parameter updated to `validateChecksum(network: Network)`, open question marked as resolved with rationale.
- `config.md`: `NetworkSetting.ledger: common.Ledger` updated to `NetworkSetting.network: common.Network`.

No other files reference `Ledger` — confirmed with a grep across `v3-sandbox/prototype-api/`.