### PR TITLE
docs(v3): define ContractCallResult in contract service spec

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.

--- a/v3-sandbox/prototype-api/service-contract.md
+++ b/v3-sandbox/prototype-api/service-contract.md
@@ -18,8 +18,19 @@ Param<$$LangType, $$SolidityType> {
     @@immutable supplier:ParamSupplier<$$SolidityType>
 }
 
+// Holds the ABI-encoded return value of a smart contract call.
+// Accessors decode by position; index 0 is the first return value in the Solidity signature.
+// All accessors are @@nullable — they return null when the value at that index is absent or is
+// a different Solidity type than requested.
 ContractCallResult {
-    //TODO: Provide a good and extentsible way to receive 0-N of the possible return types
+    @@immutable rawResult: bytes                           // raw ABI-encoded bytes from the network response
+
+    @@nullable string getString(index: int32)              // decodes a Solidity string return value
+    @@nullable bytes getBytes(index: int32)                // decodes a Solidity bytes return value
+    @@nullable int64 getInt64(index: int32)                // decodes a Solidity int64 return value
+    @@nullable uint64 getUint64(index: int32)              // decodes a Solidity uint64 return value
+    @@nullable bool getBool(index: int32)                  // decodes a Solidity bool return value
+    @@nullable common.Address getAddress(index: int32)     // decodes a Solidity address return value
 }
 
 SmartContractService {
@@ -46,3 +57,10 @@ Param<int8> int8(value:int8)
 Param<uint256> uint256(value:uint256)
 Param<int256> int256(value:int256)
 ```
+
+## Questions & Comments
+
+- Should `ContractCallResult` expose accessors by name (e.g. `getString(name: string)`) in addition to by index, using the ABI JSON attached to the call? Named access requires the caller to supply the ABI, which adds complexity but improves readability.
+- How should tuple and fixed/dynamic array return types be handled? A `getBytes` fallback lets callers decode them manually, but a typed `getArray` or `getTuple` accessor would be cleaner in languages that support it.
+- `uint64` is the largest unsigned integer type that maps cleanly across all 7 target languages. Solidity `uint256` and `int256` appear in the `//TODO` factory methods above; the same gap exists for return values. Should `ContractCallResult` expose a `BigInteger`-style accessor, or leave wide integers to `rawResult`?
+- Is `rawResult` always standard ABI encoding, or do custom precompiles return non-ABI-encoded bytes? If the latter, callers using `rawResult` directly may need to know which encoding to expect.


### PR DESCRIPTION
Closes #235.

`ContractCallResult` in `service-contract.md` was an empty stub with only a TODO comment, leaving PoC authors with no guidance on what to return from `callContractFunction`.

The type is now defined with a `rawResult: bytes` field holding the raw ABI-encoded response, and six typed accessor methods covering the most common Solidity return types: string, bytes, int64, uint64, bool, and address. Accessors work by index (position in the Solidity return signature) and return null when the requested index is absent or the type does not match, keeping the design safe across languages with no exceptions on type mismatch.

A `## Questions & Comments` section is added at the end of the file to surface the remaining open design points: named access via ABI JSON, tuple and array handling, wide integer types (uint256/int256), and whether rawResult encoding is always standard ABI.

Checked against all three acceptance criteria in the issue.