### PR TITLE
docs: propose opt-in gas estimation for ContractCallQuery

### DIFF
--- a/proposals/contract-call-query-gas-estimation.md
+++ b/proposals/contract-call-query-gas-estimation.md
@@ -30,23 +30,27 @@ sequenceDiagram
     SDK-->>User: throws (looks like the user's call failed)
 ```
 
-This proposal fixes the bug across all Hiero SDKs by adopting **opt-in
-automatic gas estimation with explicit-by-default behavior**. Three new
-entry points are added to `ContractCallQuery`:
+This proposal fixes the bug across all Hiero SDKs with three changes:
 
-1. `populateGasFromMirrorNode(client)` — async helper that fills in gas via
-   `MirrorNodeContractEstimateQuery`.
-2. `setAutomaticGasEstimation(enabled)` / `isAutomaticGasEstimation()` —
-   opt-in flag; when `true`, `execute()` and `getCost()` internally call
-   `populateGasFromMirrorNode` if gas is null.
-3. A behavior change in `execute()` and `getCost()`: when gas is null and
-   automatic estimation is disabled, fail fast with a clear `gas-not-set`
-   error instead of dispatching a guaranteed-to-fail `COST_ANSWER` request.
+1. `ContractCallQuery.populateGasFromMirrorNode(client)` — async helper that
+   fills in gas via `MirrorNodeContractEstimateQuery` and stores it on the
+   query.
+2. `Client.setAutoEstimateContractCallGas(enabled)` /
+   `Client.isAutoEstimateContractCallGas()` — a **client-level** opt-in
+   flag. When `true`, `ContractCallQuery.execute()` and `getCost()` call
+   `populateGasFromMirrorNode(client)` internally if gas is null. The flag
+   lives on the client because auto-estimation is a property of how the
+   client handles contract reads, not of any one query — this matches how
+   relay-style auto-estimation works in practice.
+3. A behavior change in `ContractCallQuery.execute()` and `getCost()`:
+   when gas is null and the client flag is disabled, fail fast with a
+   clear `gas-not-set-error` instead of dispatching a guaranteed-to-fail
+   `COST_ANSWER` request.
 
 The design keeps the existing sync setters sync, isolates the async network
 round-trip in an explicitly-async method, and avoids introducing a hidden
-Mirror Node dependency on every contract call. Callers who already call
-`setGas(...)` see no change.
+Mirror Node dependency on every contract call unless the caller opts in at
+the client level. Callers who already call `setGas(...)` see no change.
 
 This proposal scopes the fix to `ContractCallQuery`. Cost-estimation
 flakiness reported for other queries (e.g., `AccountRecordsQuery`) has a
@@ -54,46 +58,86 @@ different root cause and is out of scope.
 
 ---
 
+## Rationale — Why not just require `setGas()`?
+
+The natural pushback is "just tell callers to call `setGas(...)` like every
+other chain." This section explains why the proposal goes further and adds
+auto-estimation.
+
+1. **`ContractCallQuery` is a read query, and EVM read calls do not take
+   caller gas.** ethers.js `staticCall`, viem `readContract`, and web3.js
+   `.call()` all execute reads without a user-supplied gas value. Gas is
+   required by Hedera here only because of how `COST_ANSWER` is priced
+   (`gas × tinybars-per-gas`), not because the EVM semantically needs it
+   from the caller for a local call. Asking EVM developers to supply gas
+   for a read is a Hedera-specific quirk, not an ecosystem norm.
+2. **The Hedera JSON-RPC relay already auto-estimates** for `eth_call`.
+   This is why contracts that work through the relay (and on Hashscan)
+   fail when the same call is issued through the native SDK. The native
+   SDKs are diverging from their own relay. Putting the toggle on the
+   client matches where this behavior naturally lives: an application
+   decides once, at client-configuration time, that its contract reads
+   should behave like relay reads.
+3. **Mode A (manual gas) is unchanged.** Callers who already do offline
+   gas estimation see no behavioural change and pay no overhead. The new
+   helper and client flag are strictly additive.
+
+### Why the flag is on the `Client`, not the query
+
+Auto-estimation is a set-and-forget decision about how this application
+talks to contracts, not a per-call choice. Putting it on every query would
+either force callers to repeat the toggle at every call site or push them
+to wrap `ContractCallQuery` in a helper. A single client-level toggle
+matches the relay model and keeps the query API minimal.
+
+---
+
 ## New APIs
 
-### `ContractCallQuery` — gas estimation helpers
+### `ContractCallQuery` — gas estimation helper
 
 ```
 ContractCallQuery {
-    // Returns the Mirror Node gas estimate for this query without mutating
-    // it. Uses MirrorNodeContractEstimateQuery against the client's mirror
-    // network. Does not contact the consensus node.
-    @@async
-    @@throws(mirror-node-error)
-    int64 estimateGasFromMirrorNode(client: Client)
-
-    // Convenience: runs estimateGasFromMirrorNode(client) and stores the
-    // result via setGas(...). Returns this for chaining.
+    // Runs MirrorNodeContractEstimateQuery against the client's mirror
+    // network using this query's existing contractId, functionParameters,
+    // and sender, and stores the result via setGas(...). Returns this for
+    // chaining. Does not contact the consensus node.
     @@async
     @@throws(mirror-node-error)
     ContractCallQuery populateGasFromMirrorNode(client: Client)
+}
+```
 
-    // Opt-in flag. Default: false. When true, execute() and getCost() call
-    // populateGasFromMirrorNode(client) internally if gas is null and
-    // queryPayment is not set.
-    ContractCallQuery setAutomaticGasEstimation(enabled: bool)
+### `Client` — auto-estimation flag
 
-    bool isAutomaticGasEstimation()
+```
+Client {
+    // Opt-in flag. Default: false. When true, ContractCallQuery.execute()
+    // and ContractCallQuery.getCost() call populateGasFromMirrorNode(this)
+    // internally if the query's gas is null.
+    Client setAutoEstimateContractCallGas(enabled: bool)
+
+    bool isAutoEstimateContractCallGas()
 }
 ```
 
 Notes:
 
 - `MirrorNodeContractEstimateQuery` is already exposed in the SDKs that have
-  shipped it (e.g., hiero-sdk-js, hiero-sdk-java). The helpers above wrap
+  shipped it (e.g., hiero-sdk-js, hiero-sdk-java). The helper above wraps
   that existing functionality so callers do not have to compose it
   themselves.
-- The helper methods do not require the query to be frozen. They read the
-  query's existing `contractId`, `functionParameters`, and `sender` fields
-  exactly as a subsequent `execute(client)` would.
-- The `enabled` parameter on `setAutomaticGasEstimation` is non-nullable; the
-  flag is a tri-no-state boolean (the default `false` is taken when the
-  setter has never been called).
+- Callers who want the raw estimate without storing it (e.g., to apply a
+  safety multiplier before calling `setGas`) can use
+  `MirrorNodeContractEstimateQuery` directly. A second wrapper on
+  `ContractCallQuery` for that use case is intentionally omitted to keep
+  the API surface small.
+- The helper does not require the query to be frozen. It reads the query's
+  existing `contractId`, `functionParameters`, and `sender` fields exactly
+  as a subsequent `execute(client)` would.
+- The `enabled` parameter on `setAutoEstimateContractCallGas` is
+  non-nullable. The flag defaults to `false` (i.e. when
+  `setAutoEstimateContractCallGas(...)` has never been called).
 
 ---
 
@@ -108,12 +152,12 @@ and throws set. No new fields are added.
 ContractCallQuery {
     // Behavior when invoked:
     //   - If gas is set: unchanged behavior (proceed with getCost / execute).
-    //   - If gas is null and queryPayment is set: unchanged behavior
-    //     (getCost is skipped, queryPayment is used directly).
-    //   - If gas is null and queryPayment is not set and
-    //     isAutomaticGasEstimation() == true:
+    //   - If gas is null and client.isAutoEstimateContractCallGas() == true:
     //       call populateGasFromMirrorNode(client) internally, then proceed.
-    //   - Otherwise: throw gas-not-set-error before any consensus-node call.
+    //   - If gas is null and client.isAutoEstimateContractCallGas() == false:
+    //       throw gas-not-set-error before any consensus-node or Mirror
+    //       Node call. This applies regardless of whether queryPayment is
+    //       set.
     @@async
     @@throws(gas-not-set-error, mirror-node-error, precheck-error)
     ContractFunctionResult execute(client: Client)
@@ -124,21 +168,25 @@ ContractCallQuery {
 }
 ```
 
+A null gas value never reaches the wire under this proposal. Even if
+`queryPayment` is explicitly set, the EVM call itself still needs a
+non-null gas value, so the SDK rejects the call at the client side rather
+than dispatching an `ANSWER_ONLY` request with `gas=0`.
+
 ---
 
 ## Internal Changes
 
 The SDK's per-query pre-execution path (in JS: `Query._beforeExecute`; the
 equivalent in each other SDK) must be updated for `ContractCallQuery` to
-consult the gas value before constructing the wrapped `CostQuery`:
+consult the gas value and the client flag before constructing the wrapped
+`CostQuery`:
 
 ```mermaid
 flowchart TD
     A[execute / getCost called] --> B{gas set?}
     B -- yes --> F[run getCost on consensus node, then execute]
-    B -- no --> C{queryPayment set?}
-    C -- yes --> F
-    C -- no --> D{auto-estimation enabled?}
+    B -- no --> D{client auto-estimate enabled?}
     D -- yes --> E[populateGasFromMirrorNode]
     E --> E2{mirror call ok?}
     E2 -- yes --> F
@@ -150,16 +198,21 @@ Implementation guidance:
 
 - The `gas-not-set-error` message must list the three remediation paths:
   call `setGas(...)`, call `populateGasFromMirrorNode(client)`, or call
-  `setAutomaticGasEstimation(true)`.
+  `client.setAutoEstimateContractCallGas(true)`.
 - The Mirror Node call inside the automatic path must respect the client's
   configured Mirror Node endpoints and timeouts. A Mirror Node failure must
-  surface as `mirror-node-error`; the SDK must **not** silently fall back to
-  a `gas=0` consensus-node call.
-- Backwards compatibility: any caller already invoking `setGas(...)` or
-  `setQueryPayment(...)` sees no change. Callers who relied on the previous
-  silent failure (none expected) will now see a clearer error.
+  surface as `mirror-node-error`; the SDK must **not** silently fall back
+  to a `gas=0` consensus-node call.
+- Backwards compatibility: any caller already invoking `setGas(...)` sees
+  no change. Callers who relied on the previous silent failure (none
+  expected) will now see a clearer error. Callers who set `queryPayment`
+  but not `setGas` previously got `INSUFFICIENT_GAS` from the consensus
+  node and will now get `gas-not-set-error` from the SDK before any
+  network call (unless the client flag is enabled).
 - This proposal does not generalise to other queries. The behavior change
-  applies to `ContractCallQuery` only.
+  applies to `ContractCallQuery` only. The client flag is named
+  specifically (`AutoEstimateContractCallGas`) to leave room for
+  per-query-type toggles in the future without ambiguity.
 
 ### Response Codes
 
@@ -183,43 +236,46 @@ inside the Mirror Node helper; semantic errors propagate to the caller).
 1. **Given** a `ContractCallQuery` with `setGas` set to a sufficient value,
    **when** `execute(client)` runs, **then** the call succeeds and returns
    the contract function result.
-2. **Given** a `ContractCallQuery` with neither `setGas` nor
-   `setQueryPayment` set and `isAutomaticGasEstimation()` is `false`,
-   **when** `execute(client)` runs, **then** it throws `gas-not-set-error`
-   *before* any consensus-node or Mirror Node request is sent.
-3. **Given** a `ContractCallQuery` with `setAutomaticGasEstimation(true)`
-   and no `setGas`, **when** `execute(client)` runs, **then** the SDK calls
+2. **Given** a `ContractCallQuery` with no `setGas` and a client where
+   `isAutoEstimateContractCallGas()` is `false`, **when** `execute(client)`
+   runs, **then** it throws `gas-not-set-error` *before* any
+   consensus-node or Mirror Node request is sent.
+3. **Given** a `ContractCallQuery` with no `setGas` and a client where
+   `setAutoEstimateContractCallGas(true)` has been called, **when**
+   `execute(client)` runs, **then** the SDK calls
    `MirrorNodeContractEstimateQuery`, stores the estimate as gas, computes
    the cost via the consensus node, and the call succeeds.
 4. **Given** a `ContractCallQuery` and a reachable Mirror Node, **when**
-   `populateGasFromMirrorNode(client)` is called, **then** `getGas()` on the
-   query returns the Mirror Node estimate and a subsequent `execute(client)`
-   (without re-populating) succeeds.
-5. **Given** a `ContractCallQuery` with `setAutomaticGasEstimation(true)`
-   and a Mirror Node that returns an error, **when** `execute(client)` runs,
-   **then** it surfaces `mirror-node-error` and never sends a `gas=0`
-   request to the consensus node.
-6. **Given** a `ContractCallQuery` with `setQueryPayment` set explicitly and
-   no `setGas`, **when** `execute(client)` runs, **then** it throws
-   `gas-not-set-error` (the queryPayment covers the SDK's fee for the query,
-   but the EVM call itself still needs gas).
-7. **Given** a `ContractCallQuery` with `setGas` set below the EVM intrinsic
-   floor (e.g., 1000), **when** `execute(client)` runs, **then** the
-   consensus node returns `INSUFFICIENT_GAS` (pre-existing behavior,
+   `populateGasFromMirrorNode(client)` is called, **then** `getGas()` on
+   the query returns the Mirror Node estimate and a subsequent
+   `execute(client)` succeeds.
+5. **Given** a `ContractCallQuery` with no `setGas` and a client where
+   `setAutoEstimateContractCallGas(true)` has been called, and a Mirror
+   Node that returns an error, **when** `execute(client)` runs, **then**
+   it surfaces `mirror-node-error` and never sends a `gas=0` request to
+   the consensus node.
+6. **Given** a `ContractCallQuery` with `setQueryPayment` set explicitly
+   and no `setGas`, and a client where `isAutoEstimateContractCallGas()`
+   is `false`, **when** `execute(client)` runs, **then** it throws
+   `gas-not-set-error` before any network call.
+7. **Given** a `ContractCallQuery` with `setGas` set below the EVM
+   intrinsic floor (e.g., 1000), **when** `execute(client)` runs, **then**
+   the consensus node returns `INSUFFICIENT_GAS` (pre-existing behavior,
    unchanged).
-8. **Given** any newly constructed `ContractCallQuery`, **when**
-   `isAutomaticGasEstimation()` is read without `setAutomaticGasEstimation`
-   ever having been called, **then** it returns `false`.
+8. **Given** a freshly constructed `Client`, **when**
+   `isAutoEstimateContractCallGas()` is read without
+   `setAutoEstimateContractCallGas(...)` ever having been called, **then**
+   it returns `false`.
 
 ### TCK
 
 The tests above must be ported to the
 [hiero-sdk-tck](https://github.com/hiero-ledger/hiero-sdk-tck) repository.
 The TCK currently drives SDK servers via JSON-RPC; new RPC methods are
-needed for `populateGasFromMirrorNode`, `setAutomaticGasEstimation`, and
-`isAutomaticGasEstimation`, plus negative-path scenarios for tests 2, 5, 6,
-and 7. A tracking issue should be opened in the TCK repository before
-implementation begins and linked here.
+needed for `populateGasFromMirrorNode`, `setAutoEstimateContractCallGas`,
+and `isAutoEstimateContractCallGas`, plus negative-path scenarios for
+tests 2, 5, 6, and 7. A tracking issue should be opened in the TCK
+repository before implementation begins and linked here.
 
 ---
 
@@ -228,21 +284,9 @@ implementation begins and linked here.
 The proposal supports three caller-facing modes. Use Mode A (manual gas)
 when the caller has an accurate offline estimate, Mode B (manual populate)
 when the caller wants explicit control over when the Mirror Node round-trip
-happens, and Mode C (automatic) when the caller wants the SDK to handle gas
+happens, and Mode C (client-level automatic) when the application wants
+all `ContractCallQuery` executions on a given client to estimate gas
 end-to-end.
-
-```mermaid
-flowchart LR
-    subgraph ModeA["Mode A: Manual gas (existing, unchanged)"]
-        A1[setGas N] --> A2[execute]
-    end
-    subgraph ModeB["Mode B: Manual populate"]
-        B1[populateGasFromMirrorNode client] --> B2[execute]
-    end
-    subgraph ModeC["Mode C: Automatic (opt-in)"]
-        C1[setAutomaticGasEstimation true] --> C2[execute]
-    end
-```
 
 ### Mode A — Manual gas (existing pattern, unchanged)
 
@@ -266,13 +310,16 @@ await query.populateGasFromMirrorNode(client);
 const result = await query.execute(client);
 ```
 
-### Mode C — Automatic estimation (opt-in)
+### Mode C — Client-level automatic estimation (opt-in)
 
 ```ts
+client.setAutoEstimateContractCallGas(true);
+
+// Every ContractCallQuery executed against this client now auto-estimates
+// gas via the Mirror Node when setGas was not called.
 const query = new ContractCallQuery()
   .setContractId(contractId)
-  .setFunction("retrieve")
-  .setAutomaticGasEstimation(true);
+  .setFunction("retrieve");
 
 const result = await query.execute(client);
 ```
@@ -287,5 +334,6 @@ const query = new ContractCallQuery()
 await query.execute(client);
 // throws gas-not-set-error:
 //   "ContractCallQuery requires gas to be set. Call setGas(gas),
-//    populateGasFromMirrorNode(client), or setAutomaticGasEstimation(true)."
+//    populateGasFromMirrorNode(client), or
+//    client.setAutoEstimateContractCallGas(true)."
 ```

--- a/proposals/contract-call-query-gas-estimation.md
+++ b/proposals/contract-call-query-gas-estimation.md
@@ -1,0 +1,291 @@
+# `ContractCallQuery` Gas and Cost Estimation
+
+**Date Submitted:** 2026-05-11
+
+## Summary
+
+`ContractCallQuery.execute(client)` currently fails with `INSUFFICIENT_GAS`
+whenever the caller does not call `setGas(...)` first. The failure is reported
+against the user's call, but it actually comes from the SDK's *internal*
+`getCost()` pre-step that wraps the user's query in a `CostQuery` and asks the
+consensus node to price it. Per `services_contract_call_local.proto`, the node
+"SHALL always consume the entire amount of offered gas in determining the fee
+for this query, so accurate gas estimation is important" — the cost is defined
+as `gas × tinybars-per-gas`. With no gas set, the SDK sends `gas=0` and the
+node correctly rejects. The consensus node is behaving per spec; the bug is on
+the SDK side. See
+[hiero-sdk-js#2848](https://github.com/hiero-ledger/hiero-sdk-js/issues/2848)
+and [hiero-consensus-node#4854](https://github.com/hiero-ledger/hiero-consensus-node/issues/4854).
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant SDK as ContractCallQuery
+    participant CN as Consensus Node
+    User->>SDK: execute(client)
+    Note over SDK: no setGas, no setQueryPayment
+    SDK->>SDK: _beforeExecute -> getCost()
+    SDK->>CN: ContractCallLocal { COST_ANSWER, gas=0 }
+    CN-->>SDK: INSUFFICIENT_GAS
+    SDK-->>User: throws (looks like the user's call failed)
+```
+
+This proposal fixes the bug across all Hiero SDKs by adopting **opt-in
+automatic gas estimation with explicit-by-default behavior**. Three new
+entry points are added to `ContractCallQuery`:
+
+1. `populateGasFromMirrorNode(client)` — async helper that fills in gas via
+   `MirrorNodeContractEstimateQuery`.
+2. `setAutomaticGasEstimation(enabled)` / `isAutomaticGasEstimation()` —
+   opt-in flag; when `true`, `execute()` and `getCost()` internally call
+   `populateGasFromMirrorNode` if gas is null.
+3. A behavior change in `execute()` and `getCost()`: when gas is null and
+   automatic estimation is disabled, fail fast with a clear `gas-not-set`
+   error instead of dispatching a guaranteed-to-fail `COST_ANSWER` request.
+
+The design keeps the existing sync setters sync, isolates the async network
+round-trip in an explicitly-async method, and avoids introducing a hidden
+Mirror Node dependency on every contract call. Callers who already call
+`setGas(...)` see no change.
+
+This proposal scopes the fix to `ContractCallQuery`. Cost-estimation
+flakiness reported for other queries (e.g., `AccountRecordsQuery`) has a
+different root cause and is out of scope.
+
+---
+
+## New APIs
+
+### `ContractCallQuery` — gas estimation helpers
+
+```
+ContractCallQuery {
+    // Returns the Mirror Node gas estimate for this query without mutating
+    // it. Uses MirrorNodeContractEstimateQuery against the client's mirror
+    // network. Does not contact the consensus node.
+    @@async
+    @@throws(mirror-node-error)
+    int64 estimateGasFromMirrorNode(client: Client)
+
+    // Convenience: runs estimateGasFromMirrorNode(client) and stores the
+    // result via setGas(...). Returns this for chaining.
+    @@async
+    @@throws(mirror-node-error)
+    ContractCallQuery populateGasFromMirrorNode(client: Client)
+
+    // Opt-in flag. Default: false. When true, execute() and getCost() call
+    // populateGasFromMirrorNode(client) internally if gas is null and
+    // queryPayment is not set.
+    ContractCallQuery setAutomaticGasEstimation(enabled: bool)
+
+    bool isAutomaticGasEstimation()
+}
+```
+
+Notes:
+
+- `MirrorNodeContractEstimateQuery` is already exposed in the SDKs that have
+  shipped it (e.g., hiero-sdk-js, hiero-sdk-java). The helpers above wrap
+  that existing functionality so callers do not have to compose it
+  themselves.
+- The helper methods do not require the query to be frozen. They read the
+  query's existing `contractId`, `functionParameters`, and `sender` fields
+  exactly as a subsequent `execute(client)` would.
+- The `enabled` parameter on `setAutomaticGasEstimation` is non-nullable; the
+  flag is a tri-no-state boolean (the default `false` is taken when the
+  setter has never been called).
+
+---
+
+## Updated APIs
+
+### `ContractCallQuery` — `execute` and `getCost` behavior
+
+The methods exist already; this proposal updates their pre-execution logic
+and throws set. No new fields are added.
+
+```
+ContractCallQuery {
+    // Behavior when invoked:
+    //   - If gas is set: unchanged behavior (proceed with getCost / execute).
+    //   - If gas is null and queryPayment is set: unchanged behavior
+    //     (getCost is skipped, queryPayment is used directly).
+    //   - If gas is null and queryPayment is not set and
+    //     isAutomaticGasEstimation() == true:
+    //       call populateGasFromMirrorNode(client) internally, then proceed.
+    //   - Otherwise: throw gas-not-set-error before any consensus-node call.
+    @@async
+    @@throws(gas-not-set-error, mirror-node-error, precheck-error)
+    ContractFunctionResult execute(client: Client)
+
+    @@async
+    @@throws(gas-not-set-error, mirror-node-error)
+    Hbar getCost(client: Client)
+}
+```
+
+---
+
+## Internal Changes
+
+The SDK's per-query pre-execution path (in JS: `Query._beforeExecute`; the
+equivalent in each other SDK) must be updated for `ContractCallQuery` to
+consult the gas value before constructing the wrapped `CostQuery`:
+
+```mermaid
+flowchart TD
+    A[execute / getCost called] --> B{gas set?}
+    B -- yes --> F[run getCost on consensus node, then execute]
+    B -- no --> C{queryPayment set?}
+    C -- yes --> F
+    C -- no --> D{auto-estimation enabled?}
+    D -- yes --> E[populateGasFromMirrorNode]
+    E --> E2{mirror call ok?}
+    E2 -- yes --> F
+    E2 -- no --> EX1[throw mirror-node-error]
+    D -- no --> EX2[throw gas-not-set-error with remediation hints]
+```
+
+Implementation guidance:
+
+- The `gas-not-set-error` message must list the three remediation paths:
+  call `setGas(...)`, call `populateGasFromMirrorNode(client)`, or call
+  `setAutomaticGasEstimation(true)`.
+- The Mirror Node call inside the automatic path must respect the client's
+  configured Mirror Node endpoints and timeouts. A Mirror Node failure must
+  surface as `mirror-node-error`; the SDK must **not** silently fall back to
+  a `gas=0` consensus-node call.
+- Backwards compatibility: any caller already invoking `setGas(...)` or
+  `setQueryPayment(...)` sees no change. Callers who relied on the previous
+  silent failure (none expected) will now see a clearer error.
+- This proposal does not generalise to other queries. The behavior change
+  applies to `ContractCallQuery` only.
+
+### Response Codes
+
+No new consensus-node response codes are introduced. Existing
+`INSUFFICIENT_GAS` continues to surface when the caller (or the Mirror Node
+estimate) offers gas below the EVM intrinsic floor.
+
+#### Transaction Retry
+
+`gas-not-set-error` is a client-side validation error raised before any
+network request. It must not be retried.
+
+`mirror-node-error` from `populateGasFromMirrorNode` follows the SDK's
+existing Mirror Node retry policy (transport-level retries are handled
+inside the Mirror Node helper; semantic errors propagate to the caller).
+
+---
+
+## Test Plan
+
+1. **Given** a `ContractCallQuery` with `setGas` set to a sufficient value,
+   **when** `execute(client)` runs, **then** the call succeeds and returns
+   the contract function result.
+2. **Given** a `ContractCallQuery` with neither `setGas` nor
+   `setQueryPayment` set and `isAutomaticGasEstimation()` is `false`,
+   **when** `execute(client)` runs, **then** it throws `gas-not-set-error`
+   *before* any consensus-node or Mirror Node request is sent.
+3. **Given** a `ContractCallQuery` with `setAutomaticGasEstimation(true)`
+   and no `setGas`, **when** `execute(client)` runs, **then** the SDK calls
+   `MirrorNodeContractEstimateQuery`, stores the estimate as gas, computes
+   the cost via the consensus node, and the call succeeds.
+4. **Given** a `ContractCallQuery` and a reachable Mirror Node, **when**
+   `populateGasFromMirrorNode(client)` is called, **then** `getGas()` on the
+   query returns the Mirror Node estimate and a subsequent `execute(client)`
+   (without re-populating) succeeds.
+5. **Given** a `ContractCallQuery` with `setAutomaticGasEstimation(true)`
+   and a Mirror Node that returns an error, **when** `execute(client)` runs,
+   **then** it surfaces `mirror-node-error` and never sends a `gas=0`
+   request to the consensus node.
+6. **Given** a `ContractCallQuery` with `setQueryPayment` set explicitly and
+   no `setGas`, **when** `execute(client)` runs, **then** it throws
+   `gas-not-set-error` (the queryPayment covers the SDK's fee for the query,
+   but the EVM call itself still needs gas).
+7. **Given** a `ContractCallQuery` with `setGas` set below the EVM intrinsic
+   floor (e.g., 1000), **when** `execute(client)` runs, **then** the
+   consensus node returns `INSUFFICIENT_GAS` (pre-existing behavior,
+   unchanged).
+8. **Given** any newly constructed `ContractCallQuery`, **when**
+   `isAutomaticGasEstimation()` is read without `setAutomaticGasEstimation`
+   ever having been called, **then** it returns `false`.
+
+### TCK
+
+The tests above must be ported to the
+[hiero-sdk-tck](https://github.com/hiero-ledger/hiero-sdk-tck) repository.
+The TCK currently drives SDK servers via JSON-RPC; new RPC methods are
+needed for `populateGasFromMirrorNode`, `setAutomaticGasEstimation`, and
+`isAutomaticGasEstimation`, plus negative-path scenarios for tests 2, 5, 6,
+and 7. A tracking issue should be opened in the TCK repository before
+implementation begins and linked here.
+
+---
+
+## SDK Example
+
+The proposal supports three caller-facing modes. Use Mode A (manual gas)
+when the caller has an accurate offline estimate, Mode B (manual populate)
+when the caller wants explicit control over when the Mirror Node round-trip
+happens, and Mode C (automatic) when the caller wants the SDK to handle gas
+end-to-end.
+
+```mermaid
+flowchart LR
+    subgraph ModeA["Mode A: Manual gas (existing, unchanged)"]
+        A1[setGas N] --> A2[execute]
+    end
+    subgraph ModeB["Mode B: Manual populate"]
+        B1[populateGasFromMirrorNode client] --> B2[execute]
+    end
+    subgraph ModeC["Mode C: Automatic (opt-in)"]
+        C1[setAutomaticGasEstimation true] --> C2[execute]
+    end
+```
+
+### Mode A — Manual gas (existing pattern, unchanged)
+
+```ts
+const query = new ContractCallQuery()
+  .setContractId(contractId)
+  .setFunction("retrieve")
+  .setGas(25_000);
+
+const result = await query.execute(client);
+```
+
+### Mode B — Manual populate
+
+```ts
+const query = new ContractCallQuery()
+  .setContractId(contractId)
+  .setFunction("retrieve");
+
+await query.populateGasFromMirrorNode(client);
+const result = await query.execute(client);
+```
+
+### Mode C — Automatic estimation (opt-in)
+
+```ts
+const query = new ContractCallQuery()
+  .setContractId(contractId)
+  .setFunction("retrieve")
+  .setAutomaticGasEstimation(true);
+
+const result = await query.execute(client);
+```
+
+### Default — clear error
+
+```ts
+const query = new ContractCallQuery()
+  .setContractId(contractId)
+  .setFunction("retrieve");
+
+await query.execute(client);
+// throws gas-not-set-error:
+//   "ContractCallQuery requires gas to be set. Call setGas(gas),
+//    populateGasFromMirrorNode(client), or setAutomaticGasEstimation(true)."
+```


### PR DESCRIPTION
 ## Summary

Adds a design proposal at `proposals/contract-call-query-gas-estimation.md`
fixing `ContractCallQuery.execute(client)` when the caller does not call
`setGas(...)`. Today the SDK's internal `getCost()` sends a `COST_ANSWER`
request with `gas=0` and the consensus node correctly rejects with
`INSUFFICIENT_GAS` — the failure is from the SDK's hidden cost probe, not
the user's call.

Upstream issues:
- hiero-ledger/hiero-sdk-js#2848
- hiero-ledger/hiero-consensus-node#4854

## Design

Cross-SDK, opt-in, explicit-by-default. Three new entry points on
`ContractCallQuery`:

- `populateGasFromMirrorNode(client)` — async helper that fills gas via
  `MirrorNodeContractEstimateQuery`.
- `setAutomaticGasEstimation(enabled)` / `isAutomaticGasEstimation()` —
  opt-in flag; when `true`, `execute()` and `getCost()` internally call
  `populateGasFromMirrorNode` if gas is null.
- Behavior change: when gas is null and auto-estimation is off, `execute()`
  / `getCost()` throw `gas-not-set-error` *before* any network call, with a
  message pointing at the three remediation paths.

Sync setters stay sync. Async work lives in explicitly-async methods. No
hidden Mirror Node dependency for callers who already set gas. Scope is
`ContractCallQuery` only — other queries' cost flakiness is out of scope.

## Why not the alternatives

- **Auto-estimate by default** (the issue author's proposal): introduces a
  mandatory Mirror Node round-trip on every contract call query — hidden
  dependency, surprising failure modes when the mirror is unavailable.
- **`setCostAutomatic(true/false)` only** (the team's first idea): right
  intuition (opt-in), but the user actually needs to control *gas
  estimation*, not "cost"; with gas in hand the existing `getCost()`
  already works.

## Contents

- Summary, New APIs, Updated APIs, Internal Changes (Response Codes +
  Transaction Retry), Test Plan (8 G/W/T tests + TCK section), SDK Example
  — matches `templates/sdk-design-doc-template.md`.
- 3 Mermaid diagrams: current broken flow (sequence), proposed decision
  flow (flowchart), and the three caller-facing modes.
- All API definitions use the meta-language from `guides/api-guideline.md`.

## Follow-up

- Open a tracking issue in `hiero-sdk-tck` for the test plan once this
  proposal is approved.
- Per-SDK implementation issues to be filed against each SDK repo after
  approval.
