### PR TITLE
docs(v3): add missing entity ID types to common namespace

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.

--- a/v3-sandbox/prototype-api/common.md
+++ b/v3-sandbox/prototype-api/common.md
@@ -96,12 +96,47 @@ ContractId extends Address {
 FileId extends Address {
 }
 
+// TopicId identifies a Hedera Consensus Service topic.
+TopicId extends Address {
+}
+
+// TokenId identifies a Hedera Token Service token.
+TokenId extends Address {
+}
+
+// ScheduleId identifies a scheduled transaction.
+ScheduleId extends Address {
+}
+
+// NodeId identifies a consensus node. Note that node IDs are assigned sequentially by the network
+// and do not follow the shard.realm.num format — only the num field is meaningful.
+NodeId extends Address {
+}
+
 // factory methods of AccountId that should be added to the namespace in the best language dependent way
 
 // Parses AccountId from string format: "shard.realm.num" or "shard.realm.num-checksum"
 // @@throws(illegal-format) if format is invalid, values are negative, or parsing fails
 // Supports optional checksum suffix after dash
 @@throws(illegal-format) AccountId fromString(accountId: string)
+
+// Parses ContractId from string format: "shard.realm.num" or "shard.realm.num-checksum"
+@@throws(illegal-format) ContractId fromString(contractId: string)
+
+// Parses FileId from string format: "shard.realm.num" or "shard.realm.num-checksum"
+@@throws(illegal-format) FileId fromString(fileId: string)
+
+// Parses TopicId from string format: "shard.realm.num" or "shard.realm.num-checksum"
+@@throws(illegal-format) TopicId fromString(topicId: string)
+
+// Parses TokenId from string format: "shard.realm.num" or "shard.realm.num-checksum"
+@@throws(illegal-format) TokenId fromString(tokenId: string)
+
+// Parses ScheduleId from string format: "shard.realm.num" or "shard.realm.num-checksum"
+@@throws(illegal-format) ScheduleId fromString(scheduleId: string)
+
+// Parses NodeId from string format: num (e.g. "3") or "0.0.num"
+@@throws(illegal-format) NodeId fromString(nodeId: string)
 ```
 
 ## Questions & Comments


### PR DESCRIPTION
The common namespace defines `AccountId`, `ContractId`, and `FileId` as subtypes of `Address`, but the typed receipts table in `transactions.md` references four more entity ID types that were never defined: `TopicId`, `TokenId`, `ScheduleId`, and `NodeId`. Any SDK author trying to implement those receipts would hit an undefined type.

This adds the four missing types to `common.md`, each extending `Address` the same way the existing three do. It also adds `fromString` factory methods for each type, including `ContractId` and `FileId` which were previously missing theirs — only `AccountId` had one.

One note on `NodeId`: node IDs in Hiero are assigned sequentially and only the `num` field carries meaning. The `fromString` for it accepts both a bare number (`"3"`) and the `"0.0.num"` form to match current network conventions.

Tested by reading through the full `transactions.md` receipt table and confirming every ID type it references now has a definition in `common.md`.