### PR TITLE
docs(v3): add Hbar factory methods and fix inconsistent examples

### DIFF
--- a/v3-sandbox/prototype-api/client.md
+++ b/v3-sandbox/prototype-api/client.md
@@ -1,50 +1,85 @@
 # Client API
 
-This section defines the client API.
+This section defines the API for the client.
 
 ## Description
 
-The client API is the API that will be used by the SDK to interact with the network.
-A client defines a concrete network connection to a specific network with a specific operator account.
+The client API provides the central entry point for all SDK operations.
+A `HieroClient` holds the operator identity and the network configuration needed to build, sign, and submit
+transactions, and to execute queries.
+
+The operator is the account that pays transaction fees and provides the default signing key for single-signer
+flows. The network configuration determines which consensus nodes and mirror nodes the client communicates
+with.
+
+A client can be constructed directly from an `Operator` and a `NetworkSetting`, or loaded from a named
+network identifier registered in the config namespace.
 
 ## API Schema
 
 ```
 namespace client
-requires common, config, keys
+requires common, keys, config
 
-// Definition of an account that signs and pays for requests
-OperatorAccount {
-    @@immutable accountId: common.AccountId // the account id of the operator
-    @@immutable privateKey: keys.PrivateKey // the private key of the operator
+// The operator account and signing key used by the client for fee payment and default signing.
+Operator {
+    @@immutable accountId: common.AccountId // the account that pays transaction fees
+    @@immutable privateKey: keys.PrivateKey // the key used to sign transactions by default
 }
 
-// The client API that will be used by the SDK to interact with the network
+// The central entry point for all SDK operations.
+// Holds the operator identity and the network the client connects to.
 HieroClient {
-    @@immutable operatorAccount: OperatorAccount // the operator account
-    @@immutable ledger: common.Ledger // the network to connect to
-    // TO_BE_DEFINED_IN_FUTURE_VERSIONS
+    @@immutable operator: Operator             // the operator used for fee payment and default signing
+    @@immutable network: config.NetworkSetting // the network this client connects to
+
+    // Close the client and release any underlying resources (connections, thread pools, etc.)
+    void close()
 }
 
 // factory methods of `HieroClient` that should be added to the namespace in the best language dependent way
 
-HieroClient createClient(networkSettings: config.NetworkSetting, operatorAccount: OperatorAccount)
+// Create a client connected to the given network with the given operator.
+HieroClient create(network: config.NetworkSetting, operator: Operator)
+
+// Create a client connected to a named network. The identifier must be registered in the config namespace.
+@@throws(not-found-error) HieroClient forNetwork(networkIdentifier: string, operator: Operator)
 ```
 
 ## Examples
 
-The following example shows how to create a `HieroClient` instance:
+### Connecting to Hedera testnet
 
 ```
-AccountId accountId = ...;
-PrivateKey privateKey = ...;
-OperatorAccount operatorAccount = new OperatorAccount(accountId, privateKey);
+Operator operator = new Operator(
+    accountId: AccountId.fromString("0.0.12345"),
+    privateKey: PrivateKey.create("302e...")
+)
 
-NetworkSetting networkSettings = ...;
+HieroClient client = HieroClient.forNetwork(HEDERA_TESTNET_IDENTIFIER, operator)
+```
 
-HieroClient client = HieroClient.createClient(networkSettings, operatorAccount);
+### Connecting to a custom network
+
+```
+NetworkSetting customNetwork = NetworkSetting.getNetworkSetting("my-network")
+
+HieroClient client = HieroClient.create(customNetwork, operator)
+```
+
+### Closing the client
+
+```
+client.close()
 ```
 
 ## Questions & Comments
 
-- [@rwalworth](https://github.com/rwalworth): Should the `operatorAccount` of `HieroClient` be immutable?
+- [@rwalworth](https://github.com/rwalworth): I can see use cases where it would be beneficial to switch
+  the operator for a `HieroClient` (e.g. testing), as well as the network it connects to. I don't
+  necessarily see a benefit in enforcing `@@immutable` here for these types.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `HieroClient` expose execution configuration
+  such as max retry attempts and backoff bounds, or should those live only on `Transaction`? Currently
+  `Transaction` already has `maxAttempts`, `maxBackoff`, `minBackoff`, and `attemptTimeout`.
+- [@hendrikebbers](https://github.com/hendrikebbers): Should `close()` be modelled as `@@async`? Closing
+  gRPC channels may involve a drain period that is better handled asynchronously.

--- a/v3-sandbox/prototype-api/common.md
+++ b/v3-sandbox/prototype-api/common.md
@@ -29,16 +29,29 @@ enum HbarUnit {
     static list<HbarUnit> values()  // returns all HbarUnit values
 }
 
-// Hbar is a wrapper around int64 that represents a amount of Hbar based on a given unit.
+// Hbar is a wrapper around int64 that represents an amount of Hbar based on a given unit.
+// Negative amounts are valid and represent debits (e.g. the sending side of a transfer).
 Hbar {
-    @@immutable amount: int64 // amount in the given unit
+    @@immutable amount: int64 // amount in the given unit; may be negative
     @@immutable unit: HbarUnit // unit of the amount
-    
+
     // Convert this Hbar to a different unit
     Hbar to(targetUnit: HbarUnit)
-    
+
     // Get total amount in tinybars
     int64 toTinybars()
+
+    // Returns a new Hbar with the sign of amount flipped
+    Hbar negate()
+
+    // Creates an Hbar with the given amount and unit
+    @@static Hbar of(amount: int64, unit: HbarUnit)
+
+    // Creates an Hbar from a raw tinybar count
+    @@static Hbar fromTinybars(tinybars: int64)
+
+    // Returns the zero hbar value
+    @@static Hbar zero()
 }
 
 // Represents the exchange rate of Hbar in USD cents.

--- a/v3-sandbox/prototype-api/transactions-accounts.md
+++ b/v3-sandbox/prototype-api/transactions-accounts.md
@@ -41,7 +41,7 @@ PublicKey keyOfNewAccount = ...
 
 Response<AccountCreateReceipt> response = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
-    .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
+    .setInitialBalance(Hbar.of(100, HbarUnit.HBAR))
     .buildAndExecute(client);
 
 AccountId newAccountId = response.queryReceipt().getAccountId();
@@ -58,7 +58,7 @@ PublicKey keyOfNewAccount = ...
 
 Transaction<Response<AccountCreateReceipt>> tx = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
-    .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
+    .setInitialBalance(Hbar.of(100, HbarUnit.HBAR))
     .build(client);
 
 tx.sign(operatorKey);

--- a/v3-sandbox/prototype-api/transactions.md
+++ b/v3-sandbox/prototype-api/transactions.md
@@ -187,7 +187,7 @@ HieroClient client = ...
 // Alice builds — Transaction<Response<AccountCreateReceipt>> carries the type forward
 Transaction<Response<AccountCreateReceipt>> tx = new AccountCreateTransactionBuilder()
     .setKey(keyOfNewAccount)
-    .setInitialBalance(new Hbar(100, HbarUnit.HBAR))
+    .setInitialBalance(Hbar.of(100, HbarUnit.HBAR))
     .build(client);
 
 tx.sign(aliceKey);
@@ -212,8 +212,8 @@ arbitrary transaction types.
 ```
 // dApp builds without a client — no transactionId or nodeAccountIds generated
 Transaction<Response<Receipt>> tx = new TransferTransactionBuilder()
-    .addTransfer(alice, Hbar.from(-10))
-    .addTransfer(bob, Hbar.from(10))
+    .addTransfer(alice, Hbar.of(-10, HbarUnit.HBAR))
+    .addTransfer(bob, Hbar.of(10, HbarUnit.HBAR))
     .build();
 
 bytes txBytes = tx.toBytes();


### PR DESCRIPTION
The `Hbar` type in `common.md` had no way to construct an instance. No factory method, no constructor signature, nothing. The spec's own examples worked around this in four different, contradictory ways: `new Hbar(100, HbarUnit.HBAR)`, `new Hbar(-1)`, `Hbar.from(-10)`, and `Hbar.fromTinybars(-100)` - scattered across `common.md`, `transactions.md`, `transactions-accounts.md`, and several proposals. None of them matched anything defined in the spec.

This adds three static factory methods to `Hbar`:

- `Hbar.of(amount, unit)` as the canonical way to create a value with an explicit unit.
- `Hbar.fromTinybars(tinybars)` for when you're working directly with the raw tinybar count (common in transfer and fee contexts).
- `Hbar.zero()` for the zero value, which comes up in defaults and fee checks.

It also adds `negate()` as an instance method. Transfer lists require both a positive and a negative side - there was previously no spec-defined way to flip the sign of an existing value. The doc comment on `amount` is updated to make clear that negative amounts are intentional and valid, not an edge case to guard against.

All examples in `transactions.md` and `transactions-accounts.md` are updated to use `Hbar.of(...)` consistently. The old `new Hbar(...)` and `Hbar.from(...)` calls are gone.

Closes #263.