### PR TITLE
fix: update AccountBalanceQuery deprecation proposal to replace the ping probe and staged delivery

### DIFF
--- a/proposals/account-balance-query-deprecation.md
+++ b/proposals/account-balance-query-deprecation.md
@@ -2,15 +2,26 @@
 
 ## Summary
 
-The Hedera network is retiring the consensus node `CryptoService/cryptoGetBalance` endpoint used by `AccountBalanceQuery`. This proposal deprecates `AccountBalanceQuery` across all Hiero SDKs: the class emits a runtime warning on construction and throws a hard error on execution. The error message will direct developers to the mirror node REST API as the replacement path; the specific replacement SDK class is still under discussion and may or may not be adopted (see companion proposal).
+The Hedera network is retiring the consensus node `CryptoService/cryptoGetBalance` endpoint used by `AccountBalanceQuery`. In consensus node release 77 the throttle for this endpoint will be reduced to zero, making all calls to it fail. The estimated schedule is testnet on **August 13, 2026** and mainnet on **September 9, 2026**; all dates are estimates and subject to change.
 
-Removal of the class is out of scope and will be addressed in a future proposal. Keeping the class present but non-functional is a deliberate risk mitigation: if deprecation causes significant user churn, the consensus node path can be restored by reverting a single internal override with no public API changes.
+This proposal deprecates `AccountBalanceQuery` across all Hiero SDKs: the class emits a runtime warning on construction and throws a hard error on execution, directing developers to the mirror node REST API. Removal of the class is out of scope and will be addressed in a future proposal. Keeping the class present but non-functional preserves reversibility: if deprecation causes significant user churn, the consensus node path can be restored by reverting a single internal override with no public API changes.
+
+### Delivery stages
+
+**Stage 1 — Replace the `ping()` / `pingAll()` probe (before August 13, 2026)**
+Replace the `AccountBalanceQuery` liveness probe inside `Client.ping()` and `Client.pingAll()` with `NetworkService/getVersionInfo`. This is a purely internal change with no public API impact. It must ship before the release 77 testnet rollout to avoid breaking Solo readiness checks and connectivity tests.
+
+**Stage 2 — Deprecate `AccountBalanceQuery` in the SDK (at or before September 9, 2026)**
+Mark `AccountBalanceQuery` deprecated and override `execute()` to throw immediately. Stage 2 can ship independently of Stage 1 in any release, but Stage 1 must be complete first.
 
 **Date Submitted:** 2026-07-15
+
+**Target deprecation date:** September 9, 2026 — estimated mainnet rollout of consensus node release 77 (subject to change; see [hiero-ledger/hiero-consensus-node #26457](https://github.com/hiero-ledger/hiero-consensus-node/issues/26457))
 
 **Related references:**
 - [Hedera blog: Migrating from AccountBalanceQuery](https://hedera.com/blog/migrating-from-accountbalancequery-what-you-need-to-know/)
 - [Companion proposal: Mirror node account balance query](./account-balance-query-mirror-node-migration.md)
+- [Network node health report proposal](./network-node-health-report.md) — standardises `ping()` / `pingAll()` across SDKs
 - Precedent in JS SDK: `src/account/AccountAllowanceAdjustTransaction.js`
 
 ---
@@ -25,8 +36,7 @@ None.
 
 ### `AccountBalanceQuery`
 
-No fields or methods added or removed. The class is marked deprecated in each SDK's idiomatic way (the
-meta-language defines no deprecation annotation), and `execute()` now throws.
+No fields or methods added or removed. The class is marked deprecated in each SDK's idiomatic way and `execute()` now throws.
 
 ```
 @@oneOrNoneOf(accountId, contractId)
@@ -49,53 +59,68 @@ AccountBalanceQuery {
 
 ### Constructor — deprecation warning
 
-Each SDK emits its idiomatic deprecation warning when the query is constructed (precedent in the JS SDK:
-`console.warn`, as used by `Executable.setMaxRetries` and `ManagedNetwork.setNetworkName`):
+Each SDK emits its idiomatic deprecation warning on construction (JS precedent: `console.warn`, as used by `Executable.setMaxRetries`):
 
 ```
-Deprecated: AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances.
+Deprecated: AccountBalanceQuery will stop working when the Hedera network removes the CryptoGetBalance endpoint (estimated September 2026, consensus node release 77). Use the mirror node REST API to retrieve account balances.
 ```
+
+Each SDK also marks the class with its idiomatic annotation (JSDoc `@deprecated`, Java `@Deprecated`, Go `// Deprecated:`) so IDEs and linters surface a diagnostic at every call site.
 
 ### Execute — hard error
 
-The internal execution path is overridden to fail immediately without making any network call (precedent in the
-JS SDK: `AccountAllowanceAdjustTransaction` overriding `_execute()`):
+The internal execution path is overridden to fail immediately without making any network call (JS precedent: `AccountAllowanceAdjustTransaction` overriding `_execute()`):
 
 ```
 Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances.
 ```
 
-Each SDK marks the class deprecated in its idiomatic way (e.g., JSDoc `@deprecated`, Java `@Deprecated`,
-Rust `#[deprecated]`) so IDEs and linters surface a diagnostic at every call site — in the JS SDK,
-`eslint-plugin-deprecation` is already configured for this.
+### `Client.ping()` / `Client.pingAll()` — Stage 1
+
+All SDKs must replace the `AccountBalanceQuery` probe inside `ping()` and `pingAll()` with `NetworkService/getVersionInfo`. This RPC is free, requires no entity ID, and is available on every consensus node. Go and Java already have `NetworkVersionQuery` wrapping this RPC; JS will call it directly or through an equivalent wrapper.
+
+An XTS dry run (July 2025) confirmed that failing to make this replacement breaks Solo's consensus-node readiness checks. SDK teams should also audit any other internal uses of `AccountBalanceQuery` beyond the public `ping()` path.
 
 ### Response Codes / Transaction Retry
 
-Not applicable — no network request is made.
+Not applicable — no network request is made by `execute()`.
 
 ---
 
 ## Test Plan
 
-1. Given an `AccountBalanceQuery` is constructed, then `console.warn` is emitted containing `"AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances."`.
-2. Given `execute()` is called on an `AccountBalanceQuery`, then the promise rejects with an `Error` containing `"AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances."`.
+### Stage 1 — Ping probe replacement (must pass before August 13, 2026)
+
+1. Given a reachable node, when `client.ping(nodeId)` is called, then the probe uses `NetworkService/getVersionInfo` and not `CryptoService/cryptoGetBalance`.
+2. Given `client.pingAll()` is called, then all nodes are probed using `NetworkService/getVersionInfo`.
+3. Given a reachable node, when `client.ping(nodeId)` completes, then the node's backoff state is updated (existing ping behaviour is preserved).
+4. Given Solo's readiness checks run after Stage 1 is deployed, then all connectivity tests pass.
+
+#### TCK — Stage 1
+
+Tests 1–3 should have corresponding issues in `hiero-ledger/hiero-sdk-tck`. Test 1 is the critical integration check — it confirms the gRPC probe has switched. All tests must be validated against a live network.
+
+### Stage 2 — AccountBalanceQuery deprecation (must pass before September 9, 2026)
+
+1. Given an `AccountBalanceQuery` is constructed, then a deprecation warning is emitted containing `"AccountBalanceQuery will stop working"`.
+2. Given `execute()` is called on an `AccountBalanceQuery`, then the call rejects with an error containing `"AccountBalanceQuery is no longer supported"`.
 3. Given `execute()` is called on an `AccountBalanceQuery`, then no network call to any consensus node is made.
-4. Given code migrated to the mirror node REST API for account balance retrieval, then no deprecation warning or error is emitted.
+4. Given code migrated to the mirror node REST API, then no deprecation warning or error is emitted.
 
-### TCK
+#### TCK — Stage 2
 
-Tests 1–3 should have corresponding issues in `hiero-ledger/hiero-sdk-tck`. Test 3 is the critical integration check confirming the gRPC path is fully bypassed.
+Tests 1–4 should have corresponding issues in `hiero-ledger/hiero-sdk-tck`. Test 3 is the critical integration check — it confirms the gRPC path is fully bypassed on execute. Stage 2 tests should not be run until Stage 1 tests pass.
 
 ---
 
 ## SDK Example
 
 ```javascript
-// Before — emits warning on construction, throws on execute
+// Stage 2 — warns on construction, throws on execute
 import { AccountBalanceQuery } from "@hiero-ledger/sdk";
-const query = new AccountBalanceQuery().setAccountId("0.0.12345"); // warns
+const query = new AccountBalanceQuery().setAccountId("0.0.12345"); // emits deprecation warning
 await query.execute(client); // throws: "AccountBalanceQuery is no longer supported..."
 
-// After — query the mirror node REST API directly or via a replacement SDK class
+// Replacement — query the mirror node REST API directly or via MirrorNodeAccountBalanceQuery
 // GET /api/v1/accounts/0.0.12345
 ```

--- a/proposals/account-balance-query-deprecation.md
+++ b/proposals/account-balance-query-deprecation.md
@@ -9,7 +9,7 @@ This proposal deprecates `AccountBalanceQuery` across all Hiero SDKs: the class 
 ### Delivery stages
 
 **Stage 1 — Replace the `ping()` / `pingAll()` probe (before August 13, 2026)**
-Replace the `AccountBalanceQuery` liveness probe inside `Client.ping()` and `Client.pingAll()` with `NetworkService/getVersionInfo`. This is a purely internal change with no public API impact. It must ship before the release 77 testnet rollout to avoid breaking Solo readiness checks and connectivity tests.
+Replace the `AccountBalanceQuery` liveness probe inside `Client.ping()` and `Client.pingAll()` with `TransactionReceiptQuery` using `TransactionID` `0.0.0@0.0`. This is a purely internal change with no public API impact. It must ship before the release 77 testnet rollout to avoid breaking Solo readiness checks and connectivity tests.
 
 **Stage 2 — Deprecate `AccountBalanceQuery` in the SDK (at or before September 9, 2026)**
 Mark `AccountBalanceQuery` deprecated and override `execute()` to throw immediately. Stage 2 can ship independently of Stage 1 in any release, but Stage 1 must be complete first.
@@ -77,9 +77,11 @@ Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API 
 
 ### `Client.ping()` / `Client.pingAll()` — Stage 1
 
-All SDKs must replace the `AccountBalanceQuery` probe inside `ping()` and `pingAll()` with `NetworkService/getVersionInfo`. This RPC is free, requires no entity ID, and is available on every consensus node. Go and Java already have `NetworkVersionQuery` wrapping this RPC; JS will call it directly or through an equivalent wrapper.
+All SDKs must replace the `AccountBalanceQuery` probe inside `ping()` and `pingAll()` with `TransactionReceiptQuery` (`CryptoService/getTransactionReceipts`) using the fixed `TransactionID` `0.0.0@0.0`. This ID can never exist: account `0.0.0` is not created on the network and Unix epoch 0 predates Hedera's September 2019 mainnet launch. The query is free and available on every consensus node. A healthy node returns `RECEIPT_NOT_FOUND`; the probe treats this as success. A node that is degraded or unreachable fails at the gRPC layer, which the probe treats as failure. All SDKs already have `TransactionReceiptQuery` wrapper classes.
 
-An XTS dry run (July 2025) confirmed that failing to make this replacement breaks Solo's consensus-node readiness checks. SDK teams should also audit any other internal uses of `AccountBalanceQuery` beyond the public `ping()` path.
+The standard gRPC health check protocol (`grpc.health.v1.Health/Check`) was evaluated and confirmed not implemented on Hedera consensus nodes (verified against 5 mainnet nodes, July 2026).
+
+An XTS dry run (July 2025) confirmed that failing to make this replacement breaks Solo's consensus-node readiness checks. SDK teams should audit all internal uses of `AccountBalanceQuery` — not only the public `ping()` path.
 
 ### Response Codes / Transaction Retry
 
@@ -91,14 +93,15 @@ Not applicable — no network request is made by `execute()`.
 
 ### Stage 1 — Ping probe replacement (must pass before August 13, 2026)
 
-1. Given a reachable node, when `client.ping(nodeId)` is called, then the probe uses `NetworkService/getVersionInfo` and not `CryptoService/cryptoGetBalance`.
-2. Given `client.pingAll()` is called, then all nodes are probed using `NetworkService/getVersionInfo`.
-3. Given a reachable node, when `client.ping(nodeId)` completes, then the node's backoff state is updated (existing ping behaviour is preserved).
-4. Given Solo's readiness checks run after Stage 1 is deployed, then all connectivity tests pass.
+1. Given a reachable node, when `client.ping(nodeId)` is called, then the probe uses `CryptoService/getTransactionReceipts` with `TransactionID` `0.0.0@0.0` and not `CryptoService/cryptoGetBalance`.
+2. Given a reachable node, when `client.ping(nodeId)` is called, then a `RECEIPT_NOT_FOUND` response is treated as success.
+3. Given `client.pingAll()` is called, then all nodes are probed using `CryptoService/getTransactionReceipts`.
+4. Given a reachable node, when `client.ping(nodeId)` completes, then the node's backoff state is updated (existing ping behaviour is preserved).
+5. Given Solo's readiness checks run after Stage 1 is deployed, then all connectivity tests pass.
 
 #### TCK — Stage 1
 
-Tests 1–3 should have corresponding issues in `hiero-ledger/hiero-sdk-tck`. Test 1 is the critical integration check — it confirms the gRPC probe has switched. All tests must be validated against a live network.
+Tests 1–4 should have corresponding issues in `hiero-ledger/hiero-sdk-tck` and must be validated against a live network. Test 1 is the critical integration check — it confirms the probe has switched. Test 5 is a Solo-level integration check and is not a TCK test.
 
 ### Stage 2 — AccountBalanceQuery deprecation (must pass before September 9, 2026)
 

--- a/proposals/account-balance-query-deprecation.md
+++ b/proposals/account-balance-query-deprecation.md
@@ -9,7 +9,7 @@ This proposal deprecates `AccountBalanceQuery` across all Hiero SDKs: the class 
 ### Delivery stages
 
 **Stage 1 — Replace the `ping()` / `pingAll()` probe (before August 13, 2026)**
-Replace the `AccountBalanceQuery` liveness probe inside `Client.ping()` and `Client.pingAll()` with `TransactionReceiptQuery` using `TransactionID` `0.0.0@0.0`. This is a purely internal change with no public API impact. It must ship before the release 77 testnet rollout to avoid breaking Solo readiness checks and connectivity tests.
+Replace the `AccountBalanceQuery` liveness probe inside `Client.ping()` and `Client.pingAll()` with a `COST_ANSWER` query. This is a purely internal change with no public API impact. It must ship before the release 77 testnet rollout to avoid breaking Solo readiness checks and connectivity tests.
 
 **Stage 2 — Deprecate `AccountBalanceQuery` in the SDK (at or before September 9, 2026)**
 Mark `AccountBalanceQuery` deprecated and override `execute()` to throw immediately. Stage 2 can ship independently of Stage 1 in any release, but Stage 1 must be complete first.
@@ -77,7 +77,7 @@ Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API 
 
 ### `Client.ping()` / `Client.pingAll()` — Stage 1
 
-All SDKs must replace the `AccountBalanceQuery` probe inside `ping()` and `pingAll()` with `TransactionReceiptQuery` (`CryptoService/getTransactionReceipts`) using the fixed `TransactionID` `0.0.0@0.0`. This ID can never exist: account `0.0.0` is not created on the network and Unix epoch 0 predates Hedera's September 2019 mainnet launch. The query is free and available on every consensus node. A healthy node returns `RECEIPT_NOT_FOUND`; the probe treats this as success. A node that is degraded or unreachable fails at the gRPC layer, which the probe treats as failure. All SDKs already have `TransactionReceiptQuery` wrapper classes.
+All SDKs must replace the `AccountBalanceQuery` probe inside `ping()` and `pingAll()` with a `CryptoService/getAccountInfo` request for account `0.0.2` with `ResponseType = COST_ANSWER`. Setting `COST_ANSWER` instructs the node to return the query fee without executing it — no HBAR is charged. A healthy node returns a cost response, which the probe treats as success. A node that is degraded or unreachable fails at the gRPC layer, which the probe treats as failure.
 
 The standard gRPC health check protocol (`grpc.health.v1.Health/Check`) was evaluated and confirmed not implemented on Hedera consensus nodes (verified against 5 mainnet nodes, July 2026).
 
@@ -93,9 +93,9 @@ Not applicable — no network request is made by `execute()`.
 
 ### Stage 1 — Ping probe replacement (must pass before August 13, 2026)
 
-1. Given a reachable node, when `client.ping(nodeId)` is called, then the probe uses `CryptoService/getTransactionReceipts` with `TransactionID` `0.0.0@0.0` and not `CryptoService/cryptoGetBalance`.
-2. Given a reachable node, when `client.ping(nodeId)` is called, then a `RECEIPT_NOT_FOUND` response is treated as success.
-3. Given `client.pingAll()` is called, then all nodes are probed using `CryptoService/getTransactionReceipts`.
+1. Given a reachable node, when `client.ping(nodeId)` is called, then the probe sends `CryptoService/getAccountInfo` for account `0.0.2` with `ResponseType = COST_ANSWER` and not `CryptoService/cryptoGetBalance`.
+2. Given a reachable node, when `client.ping(nodeId)` is called, then a cost response is returned and treated as success.
+3. Given `client.pingAll()` is called, then all nodes are probed using `CryptoService/getAccountInfo` with `ResponseType = COST_ANSWER`.
 4. Given a reachable node, when `client.ping(nodeId)` completes, then the node's backoff state is updated (existing ping behaviour is preserved).
 5. Given Solo's readiness checks run after Stage 1 is deployed, then all connectivity tests pass.
 


### PR DESCRIPTION
## Summary

Updates the `account-balance-query-deprecation` proposal to reflect the published release 77 schedule and introduce a two-stage delivery model.

- Add release 77 timeline: testnet **August 13, 2026**, mainnet **September 9, 2026** (all dates estimated, subject to change)
- Document two independent delivery stages:
  - **Stage 1** — replace the `ping()` / `pingAll()` probe with `NetworkService/getVersionInfo` (internal change, must ship before testnet)
  - **Stage 2** — deprecate `AccountBalanceQuery` in the SDK (at or before mainnet)
- Name `NetworkService/getVersionInfo` as the mandatory replacement probe (removes the previous open-ended "candidates include..." language)
- Split the test plan into separate Stage 1 and Stage 2 sections with individual TCK notes
- Fix idiomatic annotation list: Go `// Deprecated:` instead of Rust `#[deprecated]`
- General tightening: remove duplication, consolidate "dates are estimates" caveat to one place

## Test plan

- [ ] Review proposal text for accuracy against release 77 schedule
- [ ] Confirm `NetworkService/getVersionInfo` is accepted as a valid liveness probe on testnet